### PR TITLE
[codex] fix claude resume session id parsing

### DIFF
--- a/code-dispatcher/main_test.go
+++ b/code-dispatcher/main_test.go
@@ -2004,6 +2004,22 @@ func TestBackendParseJSONStream_ClaudeEvents(t *testing.T) {
 	}
 }
 
+func TestBackendParseJSONStream_ClaudeResumeIgnoresHookSessionID(t *testing.T) {
+	input := `{"type":"system","subtype":"hook_started","session_id":"hook-session"}
+{"type":"system","subtype":"hook_response","session_id":"hook-session"}
+{"type":"system","subtype":"init","session_id":"resumed-session"}
+{"type":"result","subtype":"success","result":"Hello!","session_id":"resumed-session"}`
+
+	message, threadID := parseJSONStream(strings.NewReader(input))
+
+	if message != "Hello!" {
+		t.Fatalf("message=%q, want %q", message, "Hello!")
+	}
+	if threadID != "resumed-session" {
+		t.Fatalf("threadID=%q, want %q", threadID, "resumed-session")
+	}
+}
+
 func TestBackendParseJSONStream_ClaudeEvents_ItemDoesNotForceCodex(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/code-dispatcher/parser.go
+++ b/code-dispatcher/parser.go
@@ -238,7 +238,7 @@ func parseJSONStreamInternalWithHooks(r io.Reader, warnFn func(string), infoFn f
 
 		// Handle Claude events
 		if isClaude {
-			if event.SessionID != "" && threadID == "" {
+			if event.SessionID != "" && isAuthoritativeClaudeSessionEvent(event) {
 				threadID = event.SessionID
 			}
 
@@ -318,6 +318,13 @@ func parseJSONStreamInternalWithHooks(r io.Reader, warnFn func(string), infoFn f
 
 	infoFn(fmt.Sprintf("parseJSONStream completed: events=%d, message_len=%d, thread_id_found=%t", totalEvents, len(message), threadID != ""))
 	return message, threadID
+}
+
+func isAuthoritativeClaudeSessionEvent(event UnifiedEvent) bool {
+	if event.Type == "result" {
+		return true
+	}
+	return event.Type == "system" && event.Subtype == "init"
 }
 
 func hasKey(m map[string]json.RawMessage, key string) bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了 Claude 会话恢复场景下的线程ID识别问题。现在系统能够准确地从会话恢复事件中识别正确的线程ID，避免误读之前钩子事件中的会话标识。

* **Tests**
  * 增加了测试用例以验证 Claude 会话恢复时的日志流解析逻辑。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/code-dispatcher-toolkit/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->