### PR TITLE
refactor: remove test residual functions

### DIFF
--- a/code-dispatcher/logger_test.go
+++ b/code-dispatcher/logger_test.go
@@ -544,10 +544,6 @@ func TestLoggerCoverageSuite(t *testing.T) {
 		{"TestLogWriterLogLine", TestLogWriterLogLine},
 		{"TestNewLogWriterDefaultMaxLen", TestNewLogWriterDefaultMaxLen},
 		{"TestNewLogWriterDefaultLimit", TestNewLogWriterDefaultLimit},
-		{"TestRunHello", TestRunHello},
-		{"TestRunGreet", TestRunGreet},
-		{"TestRunFarewell", TestRunFarewell},
-		{"TestRunFarewellEmpty", TestRunFarewellEmpty},
 
 		{"TestParallelParseConfig_Success", TestParallelParseConfig_Success},
 		{"TestParallelParseConfig_Backend", TestParallelParseConfig_Backend},

--- a/code-dispatcher/main_test.go
+++ b/code-dispatcher/main_test.go
@@ -4169,30 +4169,6 @@ func TestBackendParseJSONStream_CoverageSuite(t *testing.T) {
 	}
 }
 
-func TestRunHello(t *testing.T) {
-	if got := hello(); got != "hello world" {
-		t.Fatalf("hello() = %q, want %q", got, "hello world")
-	}
-}
-
-func TestRunGreet(t *testing.T) {
-	if got := greet("Linus"); got != "hello Linus" {
-		t.Fatalf("greet() = %q, want %q", got, "hello Linus")
-	}
-}
-
-func TestRunFarewell(t *testing.T) {
-	if got := farewell("Linus"); got != "goodbye Linus" {
-		t.Fatalf("farewell() = %q, want %q", got, "goodbye Linus")
-	}
-}
-
-func TestRunFarewellEmpty(t *testing.T) {
-	if got := farewell(""); got != "goodbye " {
-		t.Fatalf("farewell(\"\") = %q, want %q", got, "goodbye ")
-	}
-}
-
 func TestRunTailBuffer(t *testing.T) {
 	tb := &tailBuffer{limit: 5}
 	if n, err := tb.Write([]byte("abcd")); err != nil || n != 4 {

--- a/code-dispatcher/utils.go
+++ b/code-dispatcher/utils.go
@@ -273,18 +273,6 @@ func min(a, b int) int {
 	return b
 }
 
-func hello() string {
-	return "hello world"
-}
-
-func greet(name string) string {
-	return "hello " + name
-}
-
-func farewell(name string) string {
-	return "goodbye " + name
-}
-
 const (
 	structuredReportStartMarker = "---CODE-DISPATCHER-REPORT---"
 	structuredReportEndMarker   = "---END-CODE-DISPATCHER-REPORT---"


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Delete residual tests for hello/greet/farewell helpers from main_test and logger coverage suite.

---

Linked issue: Closes #45
