### PR TITLE
refactor: add runtime asset manifest

### DIFF
--- a/code-dispatcher/config.go
+++ b/code-dispatcher/config.go
@@ -243,7 +243,7 @@ func parseArgs() (*Config, error) {
 		return nil, fmt.Errorf("task required")
 	}
 	if !backendSpecified {
-		return nil, fmt.Errorf("--backend is required (supported: codex, claude)")
+		return nil, fmt.Errorf("--backend is required (supported: %s)", supportedBackendNamesText())
 	}
 	args = filtered
 

--- a/code-dispatcher/main.go
+++ b/code-dispatcher/main.go
@@ -225,7 +225,7 @@ func run() (exitCode int) {
 			}
 
 			if !backendSpecified {
-				fmt.Fprintln(os.Stderr, "ERROR: --backend is required in --parallel mode (supported: codex, claude)")
+				fmt.Fprintf(os.Stderr, "ERROR: --backend is required in --parallel mode (supported: %s)\n", supportedBackendNamesText())
 				fmt.Fprintln(os.Stderr, "Usage examples:")
 				fmt.Fprintf(os.Stderr, "  %s --parallel --backend codex < tasks.txt\n", name)
 				fmt.Fprintf(os.Stderr, "  %s --parallel --backend claude <<'EOF'\n", name)

--- a/code-dispatcher/runtime_assets.go
+++ b/code-dispatcher/runtime_assets.go
@@ -79,6 +79,9 @@ func validateRuntimeAssetManifest(manifest runtimeAssetManifest) error {
 	if strings.TrimSpace(manifest.Binary.NameByOS["default"]) == "" {
 		return fmt.Errorf("runtime asset manifest missing binary.name_by_os.default")
 	}
+	if strings.TrimSpace(manifest.Binary.NameByOS["nt"]) == "" {
+		return fmt.Errorf("runtime asset manifest missing binary.name_by_os.nt")
+	}
 	if len(manifest.Binary.ReleaseAssets) == 0 {
 		return fmt.Errorf("runtime asset manifest missing binary.release_assets")
 	}

--- a/code-dispatcher/runtime_assets.go
+++ b/code-dispatcher/runtime_assets.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	_ "embed"
+)
+
+//go:embed runtime_assets.json
+var runtimeAssetsJSON []byte
+
+type runtimeAssetManifest struct {
+	RuntimeConfig   runtimeConfigAsset          `json:"runtime_config"`
+	Binary          runtimeBinaryAsset          `json:"binary"`
+	Backends        []runtimeBackendAsset       `json:"backends"`
+	LegacyUninstall runtimeLegacyUninstallAsset `json:"legacy_uninstall"`
+}
+
+type runtimeConfigAsset struct {
+	Template    string `json:"template"`
+	InstallPath string `json:"install_path"`
+}
+
+type runtimeBinaryAsset struct {
+	InstallDir    string                `json:"install_dir"`
+	NameByOS      map[string]string     `json:"name_by_os"`
+	ReleaseAssets []runtimeReleaseAsset `json:"release_assets"`
+}
+
+type runtimeReleaseAsset struct {
+	System   string   `json:"system"`
+	Machines []string `json:"machines"`
+	Asset    string   `json:"asset"`
+}
+
+type runtimeBackendAsset struct {
+	Name           string `json:"name"`
+	PromptTemplate string `json:"prompt_template"`
+	PromptFile     string `json:"prompt_file"`
+}
+
+type runtimeLegacyUninstallAsset struct {
+	PromptFiles []string `json:"prompt_files"`
+}
+
+var runtimeAssets = mustLoadRuntimeAssetManifest(runtimeAssetsJSON)
+
+func mustLoadRuntimeAssetManifest(data []byte) runtimeAssetManifest {
+	manifest, err := loadRuntimeAssetManifest(data)
+	if err != nil {
+		panic(err)
+	}
+	return manifest
+}
+
+func loadRuntimeAssetManifest(data []byte) (runtimeAssetManifest, error) {
+	var manifest runtimeAssetManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return manifest, fmt.Errorf("load runtime asset manifest: %w", err)
+	}
+	if err := validateRuntimeAssetManifest(manifest); err != nil {
+		return manifest, err
+	}
+	return manifest, nil
+}
+
+func validateRuntimeAssetManifest(manifest runtimeAssetManifest) error {
+	if strings.TrimSpace(manifest.RuntimeConfig.Template) == "" {
+		return fmt.Errorf("runtime asset manifest missing runtime_config.template")
+	}
+	if strings.TrimSpace(manifest.RuntimeConfig.InstallPath) == "" {
+		return fmt.Errorf("runtime asset manifest missing runtime_config.install_path")
+	}
+	if strings.TrimSpace(manifest.Binary.InstallDir) == "" {
+		return fmt.Errorf("runtime asset manifest missing binary.install_dir")
+	}
+	if strings.TrimSpace(manifest.Binary.NameByOS["default"]) == "" {
+		return fmt.Errorf("runtime asset manifest missing binary.name_by_os.default")
+	}
+	if len(manifest.Binary.ReleaseAssets) == 0 {
+		return fmt.Errorf("runtime asset manifest missing binary.release_assets")
+	}
+	for i, asset := range manifest.Binary.ReleaseAssets {
+		if strings.TrimSpace(asset.System) == "" {
+			return fmt.Errorf("runtime asset manifest release_assets[%d] missing system", i)
+		}
+		if len(asset.Machines) == 0 {
+			return fmt.Errorf("runtime asset manifest release_assets[%d] missing machines", i)
+		}
+		if strings.TrimSpace(asset.Asset) == "" {
+			return fmt.Errorf("runtime asset manifest release_assets[%d] missing asset", i)
+		}
+	}
+
+	if len(manifest.Backends) == 0 {
+		return fmt.Errorf("runtime asset manifest missing backends")
+	}
+	seen := make(map[string]struct{}, len(manifest.Backends))
+	for i, backend := range manifest.Backends {
+		name := normalizeBackendName(backend.Name)
+		if name == "" {
+			return fmt.Errorf("runtime asset manifest backends[%d] missing name", i)
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("runtime asset manifest duplicate backend %q", name)
+		}
+		seen[name] = struct{}{}
+		if strings.TrimSpace(backend.PromptTemplate) == "" {
+			return fmt.Errorf("runtime asset manifest backend %q missing prompt_template", name)
+		}
+		if strings.TrimSpace(backend.PromptFile) == "" {
+			return fmt.Errorf("runtime asset manifest backend %q missing prompt_file", name)
+		}
+	}
+	return nil
+}
+
+func runtimePromptFileForBackend(backendName string) (string, bool) {
+	name := normalizeBackendName(backendName)
+	for _, backend := range runtimeAssets.Backends {
+		if normalizeBackendName(backend.Name) == name {
+			return backend.PromptFile, true
+		}
+	}
+	return "", false
+}
+
+func runtimeBackendNames() []string {
+	names := make([]string, 0, len(runtimeAssets.Backends))
+	for _, backend := range runtimeAssets.Backends {
+		names = append(names, normalizeBackendName(backend.Name))
+	}
+	return names
+}
+
+func supportedBackendNamesText() string {
+	return strings.Join(runtimeBackendNames(), ", ")
+}

--- a/code-dispatcher/runtime_assets.json
+++ b/code-dispatcher/runtime_assets.json
@@ -1,0 +1,45 @@
+{
+  "runtime_config": {
+    "template": "templates/runtime-config.env",
+    "install_path": ".env"
+  },
+  "binary": {
+    "install_dir": "bin",
+    "name_by_os": {
+      "default": "code-dispatcher",
+      "nt": "code-dispatcher.exe"
+    },
+    "release_assets": [
+      {
+        "system": "Linux",
+        "machines": ["amd64", "x86_64"],
+        "asset": "code-dispatcher-linux-amd64"
+      },
+      {
+        "system": "Darwin",
+        "machines": ["arm64", "aarch64"],
+        "asset": "code-dispatcher-darwin-arm64"
+      },
+      {
+        "system": "Windows",
+        "machines": ["amd64", "x86_64"],
+        "asset": "code-dispatcher-windows-amd64.exe"
+      }
+    ]
+  },
+  "backends": [
+    {
+      "name": "codex",
+      "prompt_template": "prompts/codex-prompt.md",
+      "prompt_file": "codex-prompt.md"
+    },
+    {
+      "name": "claude",
+      "prompt_template": "prompts/claude-prompt.md",
+      "prompt_file": "claude-prompt.md"
+    }
+  ],
+  "legacy_uninstall": {
+    "prompt_files": ["copilot-prompt.md", "gemini-prompt.md"]
+  }
+}

--- a/code-dispatcher/runtime_assets_test.go
+++ b/code-dispatcher/runtime_assets_test.go
@@ -54,3 +54,17 @@ func TestRuntimeAssetManifestInstallTargets(t *testing.T) {
 		t.Fatalf("release asset count = %d, want 3", len(runtimeAssets.Binary.ReleaseAssets))
 	}
 }
+
+func TestRuntimeAssetManifestRequiresWindowsBinaryName(t *testing.T) {
+	manifest := runtimeAssets
+	manifest.Binary.NameByOS = map[string]string{}
+	for key, value := range runtimeAssets.Binary.NameByOS {
+		manifest.Binary.NameByOS[key] = value
+	}
+	delete(manifest.Binary.NameByOS, "nt")
+
+	err := validateRuntimeAssetManifest(manifest)
+	if err == nil || err.Error() != "runtime asset manifest missing binary.name_by_os.nt" {
+		t.Fatalf("validateRuntimeAssetManifest error = %v", err)
+	}
+}

--- a/code-dispatcher/runtime_assets_test.go
+++ b/code-dispatcher/runtime_assets_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeAssetManifestBackendsMatchRegistry(t *testing.T) {
+	names := runtimeBackendNames()
+	if len(names) != len(backendRegistry) {
+		t.Fatalf("manifest backends = %v, registry has %d entries", names, len(backendRegistry))
+	}
+
+	for _, name := range names {
+		if _, ok := backendRegistry[name]; !ok {
+			t.Fatalf("manifest backend %q missing from backendRegistry", name)
+		}
+	}
+}
+
+func TestRuntimeAssetManifestSupportedBackendNamesText(t *testing.T) {
+	if got := supportedBackendNamesText(); got != "codex, claude" {
+		t.Fatalf("supportedBackendNamesText() = %q", got)
+	}
+}
+
+func TestRuntimeAssetManifestPromptLookup(t *testing.T) {
+	promptBase := createPromptBaseForTest(t)
+
+	for _, backend := range runtimeAssets.Backends {
+		got := defaultPromptFileForBackend(backend.Name)
+		want := filepath.Join(promptBase, backend.PromptFile)
+		if got != want {
+			t.Fatalf("defaultPromptFileForBackend(%q) = %q, want %q", backend.Name, got, want)
+		}
+	}
+
+	if got := defaultPromptFileForBackend("unknown"); got != "" {
+		t.Fatalf("defaultPromptFileForBackend(unknown) = %q, want empty", got)
+	}
+}
+
+func TestRuntimeAssetManifestInstallTargets(t *testing.T) {
+	if runtimeAssets.RuntimeConfig.Template != "templates/runtime-config.env" {
+		t.Fatalf("runtime config template = %q", runtimeAssets.RuntimeConfig.Template)
+	}
+	if runtimeAssets.RuntimeConfig.InstallPath != ".env" {
+		t.Fatalf("runtime config install path = %q", runtimeAssets.RuntimeConfig.InstallPath)
+	}
+	if runtimeAssets.Binary.InstallDir != "bin" {
+		t.Fatalf("binary install dir = %q", runtimeAssets.Binary.InstallDir)
+	}
+	if len(runtimeAssets.Binary.ReleaseAssets) != 3 {
+		t.Fatalf("release asset count = %d, want 3", len(runtimeAssets.Binary.ReleaseAssets))
+	}
+}

--- a/code-dispatcher/utils.go
+++ b/code-dispatcher/utils.go
@@ -78,12 +78,11 @@ func defaultPromptFileForBackend(backendName string) string {
 		return ""
 	}
 
-	switch backend {
-	case "codex", "claude":
-		return filepath.Join(base, backend+"-prompt.md")
-	default:
+	promptFile, ok := runtimePromptFileForBackend(backend)
+	if !ok {
 		return ""
 	}
+	return filepath.Join(base, promptFile)
 }
 
 type logWriter struct {

--- a/install.py
+++ b/install.py
@@ -17,21 +17,19 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import platform
 import shutil
 import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
 
+import runtime_assets
+
 
 DEFAULT_INSTALL_DIR = "~/.code-dispatcher"
 RELEASE_REPO = "zhu-jl18/code-dispatcher-toolkit"
 RELEASE_TAG = "latest"
 HTTP_TIMEOUT_SEC = 30
-ENV_TEMPLATE = Path(__file__).resolve().parent / "templates" / "runtime-config.env"
-
-BACKENDS = ("codex", "claude")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -68,10 +66,9 @@ def _write_if_missing(path: Path, content: str, *, force: bool) -> None:
 def _install_prompts(install_dir: Path, *, force: bool) -> None:
     prompts_dir = install_dir / "prompts"
     _ensure_dir(prompts_dir)
-    bundled_dir = Path(__file__).resolve().parent / "prompts"
-    for backend in BACKENDS:
-        dest = prompts_dir / f"{backend}-prompt.md"
-        src = bundled_dir / f"{backend}-prompt.md"
+    for backend in runtime_assets.backend_assets():
+        dest = prompts_dir / runtime_assets.prompt_file(backend)
+        src = runtime_assets.prompt_template_path(backend)
         if dest.exists() and not force:
             continue
         if src.is_file():
@@ -81,29 +78,20 @@ def _install_prompts(install_dir: Path, *, force: bool) -> None:
 
 
 def _install_env_template(install_dir: Path, *, force: bool) -> None:
+    env_template_path = runtime_assets.env_template_path()
     try:
-        env_template = ENV_TEMPLATE.read_text(encoding="utf-8")
+        env_template = env_template_path.read_text(encoding="utf-8")
     except FileNotFoundError as e:
-        raise RuntimeError(f"required env template not found: {ENV_TEMPLATE}") from e
+        raise RuntimeError(f"required env template not found: {env_template_path}") from e
     except OSError as e:
-        raise RuntimeError(f"failed to read env template {ENV_TEMPLATE}: {e}") from e
+        raise RuntimeError(f"failed to read env template {env_template_path}: {e}") from e
 
-    _write_if_missing(install_dir / ".env", env_template, force=force)
+    _write_if_missing(runtime_assets.env_install_path(install_dir), env_template, force=force)
 
 
 def _get_artifact_name() -> str:
     """Return release asset name for the current OS/arch."""
-    system = platform.system()
-    machine = platform.machine().lower()
-
-    if system == "Windows" and machine in ("amd64", "x86_64"):
-        return "code-dispatcher-windows-amd64.exe"
-    if system == "Darwin" and machine in ("arm64", "aarch64"):
-        return "code-dispatcher-darwin-arm64"
-    if system == "Linux" and machine in ("amd64", "x86_64"):
-        return "code-dispatcher-linux-amd64"
-
-    raise RuntimeError(f"unsupported platform for release asset: {system}/{machine}")
+    return runtime_assets.artifact_name_for_current_platform()
 
 
 def _github_headers() -> dict[str, str]:
@@ -182,10 +170,9 @@ def _download_to_path(url: str, out: Path) -> None:
 
 
 def _install_router_from_release(install_dir: Path, *, force: bool) -> Path:
-    bin_dir = install_dir / "bin"
+    bin_dir = install_dir / runtime_assets.binary_install_dir_name()
     _ensure_dir(bin_dir)
-    exe_name = "code-dispatcher.exe" if os.name == "nt" else "code-dispatcher"
-    out = bin_dir / exe_name
+    out = bin_dir / runtime_assets.binary_name()
 
     if out.exists() and not force:
         return out
@@ -254,7 +241,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     print(f"Installed to: {install_dir}")
-    print(f"- env:      {install_dir / '.env'}")
+    print(f"- env:      {runtime_assets.env_install_path(install_dir)}")
     print(f"- prompts:  {install_dir / 'prompts'} (*-prompt.md default templates)")
     if router_path is not None:
         print(f"- binary:   {router_path} (downloaded from GitHub release {RELEASE_REPO}@{RELEASE_TAG})")

--- a/runtime_assets.py
+++ b/runtime_assets.py
@@ -1,0 +1,121 @@
+"""Shared runtime asset manifest helpers for installer tooling."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+MANIFEST_PATH = PROJECT_ROOT / "code-dispatcher" / "runtime_assets.json"
+
+
+def _load_manifest() -> dict[str, Any]:
+    try:
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError as e:
+        raise RuntimeError(f"runtime asset manifest not found: {MANIFEST_PATH}") from e
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"invalid runtime asset manifest: {MANIFEST_PATH}") from e
+
+    if not isinstance(data, dict):
+        raise RuntimeError("runtime asset manifest must be a JSON object")
+    return data
+
+
+MANIFEST = _load_manifest()
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"runtime asset manifest {label} must be an object")
+    return value
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise RuntimeError(f"runtime asset manifest {label} must be a list")
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"runtime asset manifest {label} must be a non-empty string")
+    return value
+
+
+def runtime_config() -> dict[str, Any]:
+    return _mapping(MANIFEST.get("runtime_config"), "runtime_config")
+
+
+def binary() -> dict[str, Any]:
+    return _mapping(MANIFEST.get("binary"), "binary")
+
+
+def backend_assets() -> list[dict[str, Any]]:
+    backends = _list(MANIFEST.get("backends"), "backends")
+    return [_mapping(backend, f"backends[{idx}]") for idx, backend in enumerate(backends)]
+
+
+def env_template_path() -> Path:
+    return PROJECT_ROOT / _string(runtime_config().get("template"), "runtime_config.template")
+
+
+def env_install_path(install_dir: Path) -> Path:
+    return install_dir / _string(runtime_config().get("install_path"), "runtime_config.install_path")
+
+
+def binary_install_dir_name() -> str:
+    return _string(binary().get("install_dir"), "binary.install_dir")
+
+
+def binary_name() -> str:
+    names = _mapping(binary().get("name_by_os"), "binary.name_by_os")
+    key = "nt" if os.name == "nt" else "default"
+    return _string(names.get(key), f"binary.name_by_os.{key}")
+
+
+def binary_path(install_dir: Path) -> Path:
+    return install_dir / binary_install_dir_name() / binary_name()
+
+
+def prompt_template_path(backend: dict[str, Any]) -> Path:
+    return PROJECT_ROOT / _string(backend.get("prompt_template"), "backend.prompt_template")
+
+
+def prompt_file(backend: dict[str, Any]) -> str:
+    return _string(backend.get("prompt_file"), "backend.prompt_file")
+
+
+def prompt_install_files() -> list[str]:
+    return [prompt_file(backend) for backend in backend_assets()]
+
+
+def legacy_prompt_files() -> list[str]:
+    legacy = _mapping(MANIFEST.get("legacy_uninstall"), "legacy_uninstall")
+    files = _list(legacy.get("prompt_files"), "legacy_uninstall.prompt_files")
+    return [_string(file, "legacy_uninstall.prompt_files[]") for file in files]
+
+
+def uninstall_prompt_files() -> list[str]:
+    return prompt_install_files() + legacy_prompt_files()
+
+
+def artifact_name_for_current_platform() -> str:
+    system = platform.system()
+    machine = platform.machine().lower()
+    release_assets = _list(binary().get("release_assets"), "binary.release_assets")
+
+    for idx, raw_asset in enumerate(release_assets):
+        asset = _mapping(raw_asset, f"binary.release_assets[{idx}]")
+        if _string(asset.get("system"), "release_asset.system") != system:
+            continue
+        machines = _list(asset.get("machines"), "release_asset.machines")
+        normalized = [_string(item, "release_asset.machines[]").lower() for item in machines]
+        if machine in normalized:
+            return _string(asset.get("asset"), "release_asset.asset")
+
+    raise RuntimeError(f"unsupported platform for release asset: {system}/{machine}")

--- a/runtime_assets.py
+++ b/runtime_assets.py
@@ -19,11 +19,32 @@ def _load_manifest() -> dict[str, Any]:
     except FileNotFoundError as e:
         raise RuntimeError(f"runtime asset manifest not found: {MANIFEST_PATH}") from e
     except json.JSONDecodeError as e:
-        raise RuntimeError(f"invalid runtime asset manifest: {MANIFEST_PATH}") from e
+        raise RuntimeError(
+            f"invalid runtime asset manifest: {MANIFEST_PATH}: "
+            f"line {e.lineno}, column {e.colno}: {e.msg}"
+        ) from e
+    except OSError as e:
+        raise RuntimeError(f"failed to read runtime asset manifest: {MANIFEST_PATH}: {e}") from e
 
     if not isinstance(data, dict):
         raise RuntimeError("runtime asset manifest must be a JSON object")
+    _validate_binary_names(data)
     return data
+
+
+def _validate_binary_names(data: dict[str, Any]) -> None:
+    binary = data.get("binary")
+    if not isinstance(binary, dict):
+        raise RuntimeError("runtime asset manifest binary must be an object")
+    names = binary.get("name_by_os")
+    if not isinstance(names, dict):
+        raise RuntimeError("runtime asset manifest binary.name_by_os must be an object")
+    for key in ("default", "nt"):
+        value = names.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise RuntimeError(
+                f"runtime asset manifest binary.name_by_os.{key} must be a non-empty string"
+            )
 
 
 MANIFEST = _load_manifest()

--- a/test_runtime_assets.py
+++ b/test_runtime_assets.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import install
+import runtime_assets
+import uninstall
+
+
+class RuntimeAssetsTests(unittest.TestCase):
+    def test_prompt_assets_are_shared_by_installer_and_uninstaller(self) -> None:
+        self.assertEqual(
+            runtime_assets.prompt_install_files(),
+            ["codex-prompt.md", "claude-prompt.md"],
+        )
+        self.assertEqual(
+            runtime_assets.uninstall_prompt_files(),
+            [
+                "codex-prompt.md",
+                "claude-prompt.md",
+                "copilot-prompt.md",
+                "gemini-prompt.md",
+            ],
+        )
+
+    def test_skip_dispatcher_install_writes_manifest_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            install_dir = Path(raw_dir)
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = install.main(["--install-dir", str(install_dir), "--skip-dispatcher"])
+
+            self.assertEqual(rc, 0)
+            self.assertTrue((install_dir / ".env").is_file())
+            self.assertTrue((install_dir / "prompts" / "codex-prompt.md").is_file())
+            self.assertTrue((install_dir / "prompts" / "claude-prompt.md").is_file())
+
+    def test_uninstall_removes_manifest_assets_and_legacy_prompts(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            install_dir = Path(raw_dir)
+            (install_dir / "bin").mkdir(parents=True)
+            (install_dir / "prompts").mkdir(parents=True)
+            runtime_assets.env_install_path(install_dir).write_text("env", encoding="utf-8")
+            runtime_assets.binary_path(install_dir).write_text("bin", encoding="utf-8")
+            for prompt_file in runtime_assets.uninstall_prompt_files():
+                (install_dir / "prompts" / prompt_file).write_text("prompt", encoding="utf-8")
+            unrelated = install_dir / "prompts" / "custom.md"
+            unrelated.write_text("keep", encoding="utf-8")
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = uninstall.main(["--install-dir", str(install_dir), "--yes"])
+
+            self.assertEqual(rc, 0)
+            self.assertFalse(runtime_assets.env_install_path(install_dir).exists())
+            self.assertFalse(runtime_assets.binary_path(install_dir).exists())
+            for prompt_file in runtime_assets.uninstall_prompt_files():
+                self.assertFalse((install_dir / "prompts" / prompt_file).exists())
+            self.assertTrue(unrelated.is_file())
+
+    def test_artifact_name_comes_from_manifest(self) -> None:
+        with mock.patch("platform.system", return_value="Linux"), mock.patch(
+            "platform.machine", return_value="x86_64"
+        ):
+            self.assertEqual(install._get_artifact_name(), "code-dispatcher-linux-amd64")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_runtime_assets.py
+++ b/test_runtime_assets.py
@@ -36,9 +36,9 @@ class RuntimeAssetsTests(unittest.TestCase):
                 rc = install.main(["--install-dir", str(install_dir), "--skip-dispatcher"])
 
             self.assertEqual(rc, 0)
-            self.assertTrue((install_dir / ".env").is_file())
-            self.assertTrue((install_dir / "prompts" / "codex-prompt.md").is_file())
-            self.assertTrue((install_dir / "prompts" / "claude-prompt.md").is_file())
+            self.assertTrue(runtime_assets.env_install_path(install_dir).is_file())
+            for prompt_file in runtime_assets.prompt_install_files():
+                self.assertTrue((install_dir / "prompts" / prompt_file).is_file())
 
     def test_uninstall_removes_manifest_assets_and_legacy_prompts(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:

--- a/uninstall.py
+++ b/uninstall.py
@@ -7,13 +7,12 @@ Removes only the files installed by ./install.py and leaves unrelated user files
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
+
+import runtime_assets
 
 
 DEFAULT_INSTALL_DIR = "~/.code-dispatcher"
-BACKENDS = ("codex", "claude")
-LEGACY_PROMPT_FILES = ("copilot-prompt.md", "gemini-prompt.md")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -65,11 +64,9 @@ def main(argv: list[str] | None = None) -> int:
             print("Aborted.")
             return 0
 
-    exe_name = "code-dispatcher.exe" if os.name == "nt" else "code-dispatcher"
-
     targets = [
-        install_dir / ".env",
-        install_dir / "bin" / exe_name,
+        runtime_assets.env_install_path(install_dir),
+        runtime_assets.binary_path(install_dir),
     ]
 
     removed = 0
@@ -80,9 +77,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Removed: {path}")
 
     prompts_dir = install_dir / "prompts"
-    prompt_files = [f"{backend}-prompt.md" for backend in BACKENDS]
-    prompt_files.extend(LEGACY_PROMPT_FILES)
-    for prompt_file in prompt_files:
+    for prompt_file in runtime_assets.uninstall_prompt_files():
         path = prompts_dir / prompt_file
         if _unlink(path):
             removed += 1


### PR DESCRIPTION
## Summary by Sourcery

Introduce a shared runtime asset manifest for dispatcher binaries, config, and backend prompts, and wire installers and runtime to consume it.

Enhancements:
- Centralize runtime asset metadata (binary, env config, prompts, legacy uninstall targets) in a JSON manifest consumed by both Go runtime and Python installer tooling.
- Refactor installer and uninstaller scripts to derive env, binary, and prompt paths from the shared manifest instead of hardcoded values.
- Extend dispatcher runtime to look up prompt files and supported backend names from the manifest, improving backend configurability.

Tests:
- Add Python tests to verify installer/uninstaller behavior against the manifest and platform-specific artifact resolution.
- Add Go tests to validate manifest contents, backend registry alignment, and prompt resolution from the runtime asset manifest.

---

Linked issue: Closes #48
