### PR TITLE
refactor: deepen backend execution policy

### DIFF
--- a/code-dispatcher/backend.go
+++ b/code-dispatcher/backend.go
@@ -1,14 +1,31 @@
 package main
 
-import "strings"
+import (
+	"io"
+	"strings"
+)
 
 // Backend defines the contract for invoking different AI CLI backends.
-// Each backend is responsible for supplying the executable command and
-// building the argument list based on the dispatcher config.
+// Each backend owns the policy for turning dispatcher config into a ready
+// backend invocation.
 type Backend interface {
 	Name() string
 	BuildArgs(cfg *Config, targetArg string) []string
 	Command() string
+	BuildInvocation(cfg *Config, targetArg string) BackendInvocation
+}
+
+type BackendStreamParser func(r io.Reader, warnFn func(string), infoFn func(string), onMessage func(), onComplete func()) (message, threadID string)
+
+type BackendInvocation struct {
+	BackendName          string
+	Command              string
+	Args                 []string
+	Env                  map[string]string
+	UnsetEnvKeys         []string
+	WorkDir              string
+	StderrFilterPatterns []string
+	ParseStream          BackendStreamParser
 }
 
 type CodexBackend struct{}
@@ -20,6 +37,16 @@ func (CodexBackend) Command() string {
 func (CodexBackend) BuildArgs(cfg *Config, targetArg string) []string {
 	return buildCodexArgs(cfg, targetArg)
 }
+func (b CodexBackend) BuildInvocation(cfg *Config, targetArg string) BackendInvocation {
+	return BackendInvocation{
+		BackendName:          b.Name(),
+		Command:              b.Command(),
+		Args:                 b.BuildArgs(cfg, targetArg),
+		Env:                  runtimeInjectedEnvForInvocation(),
+		StderrFilterPatterns: codexNoisePatterns,
+		ParseStream:          parseStreamForBackend(b.Name()),
+	}
+}
 
 type ClaudeBackend struct{}
 
@@ -30,14 +57,24 @@ func (ClaudeBackend) Command() string {
 func (ClaudeBackend) BuildArgs(cfg *Config, targetArg string) []string {
 	return buildClaudeArgs(cfg, targetArg)
 }
+func (b ClaudeBackend) BuildInvocation(cfg *Config, targetArg string) BackendInvocation {
+	workDir := ""
+	if cfg != nil && cfg.Mode != "resume" && strings.TrimSpace(cfg.WorkDir) != "" {
+		workDir = cfg.WorkDir
+	}
+	return BackendInvocation{
+		BackendName:  b.Name(),
+		Command:      b.Command(),
+		Args:         b.BuildArgs(cfg, targetArg),
+		Env:          runtimeInjectedEnvForInvocation(),
+		UnsetEnvKeys: []string{"CLAUDECODE"},
+		WorkDir:      workDir,
+		ParseStream:  parseStreamForBackend(b.Name()),
+	}
+}
 
 func runtimeEnvForBackend(backendName string) map[string]string {
-	env := runtimeInjectedEnv()
-	if len(env) == 0 {
-		return nil
-	}
-
-	return env
+	return runtimeInjectedEnvForInvocation()
 }
 
 func runtimeUnsetEnvKeysForBackend(backendName string) []string {
@@ -58,6 +95,78 @@ func resolveBackendModel(backendName string) string {
 		return ""
 	}
 	return strings.TrimSpace(val)
+}
+
+func runtimeInjectedEnvForInvocation() map[string]string {
+	env := runtimeInjectedEnv()
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
+func parseStreamForBackend(backendName string) BackendStreamParser {
+	return func(r io.Reader, warnFn func(string), infoFn func(string), onMessage func(), onComplete func()) (string, string) {
+		return parseBackendStreamInternal(r, backendName, warnFn, infoFn, onMessage, onComplete)
+	}
+}
+
+func legacyBackendInvocation(backendName string, commandName string, args []string) BackendInvocation {
+	name := normalizeBackendName(backendName)
+	invocation := BackendInvocation{
+		BackendName:  name,
+		Command:      commandName,
+		Args:         args,
+		Env:          runtimeEnvForBackend(name),
+		UnsetEnvKeys: runtimeUnsetEnvKeysForBackend(name),
+		ParseStream:  parseStreamForBackend(name),
+	}
+	if name == "codex" {
+		invocation.StderrFilterPatterns = codexNoisePatterns
+	}
+	if name == "claude" {
+		invocation.UnsetEnvKeys = []string{"CLAUDECODE"}
+	}
+	return invocation
+}
+
+func buildCodexArgs(cfg *Config, targetArg string) []string {
+	if cfg == nil {
+		panic("buildCodexArgs: nil config")
+	}
+
+	var resumeSessionID string
+	isResume := cfg.Mode == "resume"
+	if isResume {
+		resumeSessionID = strings.TrimSpace(cfg.SessionID)
+		if resumeSessionID == "" {
+			logError("invalid config: resume mode requires non-empty session_id")
+			isResume = false
+		}
+	}
+
+	args := []string{"exec"}
+
+	if model := resolveBackendModel("codex"); model != "" {
+		args = append(args, "-m", model)
+	}
+
+	args = append(args, "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check")
+
+	if isResume {
+		return append(args,
+			"--json",
+			"resume",
+			resumeSessionID,
+			targetArg,
+		)
+	}
+
+	return append(args,
+		"-C", cfg.WorkDir,
+		"--json",
+		targetArg,
+	)
 }
 
 func buildClaudeArgs(cfg *Config, targetArg string) []string {

--- a/code-dispatcher/backend.go
+++ b/code-dispatcher/backend.go
@@ -73,7 +73,7 @@ func (b ClaudeBackend) BuildInvocation(cfg *Config, targetArg string) BackendInv
 	}
 }
 
-func runtimeEnvForBackend(backendName string) map[string]string {
+func runtimeEnvForInvocation() map[string]string {
 	return runtimeInjectedEnvForInvocation()
 }
 
@@ -111,21 +111,25 @@ func parseStreamForBackend(backendName string) BackendStreamParser {
 	}
 }
 
-func legacyBackendInvocation(backendName string, commandName string, args []string) BackendInvocation {
+func legacyBackendInvocation(cfg *Config, commandName string, args []string) BackendInvocation {
+	backendName := ""
+	if cfg != nil {
+		backendName = cfg.Backend
+	}
 	name := normalizeBackendName(backendName)
 	invocation := BackendInvocation{
 		BackendName:  name,
 		Command:      commandName,
 		Args:         args,
-		Env:          runtimeEnvForBackend(name),
+		Env:          runtimeEnvForInvocation(),
 		UnsetEnvKeys: runtimeUnsetEnvKeysForBackend(name),
 		ParseStream:  parseStreamForBackend(name),
 	}
 	if name == "codex" {
 		invocation.StderrFilterPatterns = codexNoisePatterns
 	}
-	if name == "claude" {
-		invocation.UnsetEnvKeys = []string{"CLAUDECODE"}
+	if name == "claude" && cfg != nil && cfg.Mode != "resume" && strings.TrimSpace(cfg.WorkDir) != "" {
+		invocation.WorkDir = cfg.WorkDir
 	}
 	return invocation
 }

--- a/code-dispatcher/backend_test.go
+++ b/code-dispatcher/backend_test.go
@@ -171,11 +171,11 @@ func TestBackendInvocationPolicy(t *testing.T) {
 	})
 }
 
-func TestRuntimeEnvForBackend(t *testing.T) {
+func TestRuntimeEnvForInvocation(t *testing.T) {
 	t.Run("returns nil when no runtime settings", func(t *testing.T) {
 		setRuntimeSettingsForTest(map[string]string{})
 		t.Cleanup(resetRuntimeSettingsForTest)
-		if got := runtimeEnvForBackend("claude"); len(got) != 0 {
+		if got := runtimeEnvForInvocation(); len(got) != 0 {
 			t.Fatalf("got %v, want nil/empty", got)
 		}
 	})
@@ -189,7 +189,7 @@ func TestRuntimeEnvForBackend(t *testing.T) {
 		})
 		t.Cleanup(resetRuntimeSettingsForTest)
 
-		got := runtimeEnvForBackend("claude")
+		got := runtimeEnvForInvocation()
 		if got["ANTHROPIC_API_KEY"] != "secret" || got["FOO"] != "bar" {
 			t.Fatalf("got %v, want ANTHROPIC_API_KEY/FOO", got)
 		}

--- a/code-dispatcher/backend_test.go
+++ b/code-dispatcher/backend_test.go
@@ -59,7 +59,7 @@ func TestVariousBackendsBuildArgs(t *testing.T) {
 		backend := CodexBackend{}
 		cfg := &Config{Mode: "new", WorkDir: "/tmp"}
 		got := backend.BuildArgs(cfg, "task")
-		want := []string{"e", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/tmp", "--json", "task"}
+		want := []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/tmp", "--json", "task"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("got %v, want %v", got, want)
 		}
@@ -85,6 +85,90 @@ func TestClaudeBuildArgs_BackendMetadata(t *testing.T) {
 			t.Fatalf("Command() = %s, want %s", got, tt.command)
 		}
 	}
+}
+
+func TestBackendInvocationPolicy(t *testing.T) {
+	t.Run("codex owns command args env filter and parser policy", func(t *testing.T) {
+		setRuntimeSettingsForTest(map[string]string{
+			"CODE_DISPATCHER_TIMEOUT": "10",
+			"OPENAI_API_KEY":          "secret",
+		})
+		t.Cleanup(resetRuntimeSettingsForTest)
+
+		cfg := &Config{Mode: "new", WorkDir: "/repo", Backend: "codex"}
+		invocation := CodexBackend{}.BuildInvocation(cfg, "task")
+
+		if invocation.BackendName != "codex" {
+			t.Fatalf("BackendName = %q", invocation.BackendName)
+		}
+		if invocation.Command != "codex" {
+			t.Fatalf("Command = %q", invocation.Command)
+		}
+		wantArgs := []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/repo", "--json", "task"}
+		if !reflect.DeepEqual(invocation.Args, wantArgs) {
+			t.Fatalf("Args = %v, want %v", invocation.Args, wantArgs)
+		}
+		if invocation.Env["OPENAI_API_KEY"] != "secret" {
+			t.Fatalf("Env = %v, want OPENAI_API_KEY", invocation.Env)
+		}
+		if _, ok := invocation.Env["CODE_DISPATCHER_TIMEOUT"]; ok {
+			t.Fatalf("Env should not include dispatcher control keys: %v", invocation.Env)
+		}
+		if invocation.WorkDir != "" {
+			t.Fatalf("Codex WorkDir = %q, want empty because -C carries workdir", invocation.WorkDir)
+		}
+		if len(invocation.StderrFilterPatterns) == 0 {
+			t.Fatalf("Codex invocation should carry stderr filter patterns")
+		}
+		if invocation.ParseStream == nil {
+			t.Fatalf("Codex invocation missing stream parser")
+		}
+	})
+
+	t.Run("claude owns command args env unset workdir and parser policy", func(t *testing.T) {
+		setRuntimeSettingsForTest(map[string]string{
+			"CODE_DISPATCHER_TIMEOUT": "10",
+			"ANTHROPIC_API_KEY":       "secret",
+		})
+		t.Cleanup(resetRuntimeSettingsForTest)
+
+		cfg := &Config{Mode: "new", WorkDir: "/repo", Backend: "claude"}
+		invocation := ClaudeBackend{}.BuildInvocation(cfg, "task")
+
+		if invocation.BackendName != "claude" {
+			t.Fatalf("BackendName = %q", invocation.BackendName)
+		}
+		if invocation.Command != "claude" {
+			t.Fatalf("Command = %q", invocation.Command)
+		}
+		wantArgs := []string{"-p", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose", "task"}
+		if !reflect.DeepEqual(invocation.Args, wantArgs) {
+			t.Fatalf("Args = %v, want %v", invocation.Args, wantArgs)
+		}
+		if invocation.Env["ANTHROPIC_API_KEY"] != "secret" {
+			t.Fatalf("Env = %v, want ANTHROPIC_API_KEY", invocation.Env)
+		}
+		if !reflect.DeepEqual(invocation.UnsetEnvKeys, []string{"CLAUDECODE"}) {
+			t.Fatalf("UnsetEnvKeys = %v", invocation.UnsetEnvKeys)
+		}
+		if invocation.WorkDir != "/repo" {
+			t.Fatalf("WorkDir = %q, want /repo", invocation.WorkDir)
+		}
+		if len(invocation.StderrFilterPatterns) != 0 {
+			t.Fatalf("Claude invocation should not carry stderr filters: %v", invocation.StderrFilterPatterns)
+		}
+		if invocation.ParseStream == nil {
+			t.Fatalf("Claude invocation missing stream parser")
+		}
+	})
+
+	t.Run("claude resume leaves workdir empty", func(t *testing.T) {
+		cfg := &Config{Mode: "resume", SessionID: "sid", WorkDir: "/repo", Backend: "claude"}
+		invocation := ClaudeBackend{}.BuildInvocation(cfg, "task")
+		if invocation.WorkDir != "" {
+			t.Fatalf("resume WorkDir = %q, want empty", invocation.WorkDir)
+		}
+	})
 }
 
 func TestRuntimeEnvForBackend(t *testing.T) {
@@ -172,7 +256,7 @@ func TestCodexBuildArgs_WithModel(t *testing.T) {
 
 	cfg := &Config{Mode: "new", WorkDir: "/tmp"}
 	got := buildCodexArgs(cfg, "task")
-	want := []string{"e", "-m", "o3", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/tmp", "--json", "task"}
+	want := []string{"exec", "-m", "o3", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/tmp", "--json", "task"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}

--- a/code-dispatcher/executor.go
+++ b/code-dispatcher/executor.go
@@ -42,14 +42,25 @@ type processHandle interface {
 
 // realCmd implements commandRunner using exec.Cmd
 type realCmd struct {
-	cmd *exec.Cmd
+	cmd          *exec.Cmd
+	stdoutWriter *os.File
+	stderrWriter *os.File
 }
 
 func (r *realCmd) Start() error {
 	if r.cmd == nil {
 		return errors.New("command is nil")
 	}
-	return r.cmd.Start()
+	err := r.cmd.Start()
+	if r.stdoutWriter != nil {
+		_ = r.stdoutWriter.Close()
+		r.stdoutWriter = nil
+	}
+	if r.stderrWriter != nil {
+		_ = r.stderrWriter.Close()
+		r.stderrWriter = nil
+	}
+	return err
 }
 
 func (r *realCmd) Wait() error {
@@ -63,14 +74,38 @@ func (r *realCmd) StdoutPipe() (io.ReadCloser, error) {
 	if r.cmd == nil {
 		return nil, errors.New("command is nil")
 	}
-	return r.cmd.StdoutPipe()
+	if r.cmd.Stdout != nil {
+		return nil, errors.New("stdout already set")
+	}
+	if r.cmd.Process != nil {
+		return nil, errors.New("stdout pipe after process started")
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	r.cmd.Stdout = writer
+	r.stdoutWriter = writer
+	return reader, nil
 }
 
 func (r *realCmd) StderrPipe() (io.ReadCloser, error) {
 	if r.cmd == nil {
 		return nil, errors.New("command is nil")
 	}
-	return r.cmd.StderrPipe()
+	if r.cmd.Stderr != nil {
+		return nil, errors.New("stderr already set")
+	}
+	if r.cmd.Process != nil {
+		return nil, errors.New("stderr pipe after process started")
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	r.cmd.Stderr = writer
+	r.stderrWriter = writer
+	return reader, nil
 }
 
 func (r *realCmd) StdinPipe() (io.WriteCloser, error) {

--- a/code-dispatcher/executor.go
+++ b/code-dispatcher/executor.go
@@ -627,11 +627,11 @@ func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Ba
 	invocation := BackendInvocation{}
 	switch {
 	case useCustomArgs:
-		invocation = legacyBackendInvocation(cfg.Backend, commandName, customArgs)
+		invocation = legacyBackendInvocation(cfg, commandName, customArgs)
 	case backend != nil:
 		invocation = backend.BuildInvocation(cfg, targetArg)
 	default:
-		invocation = legacyBackendInvocation(cfg.Backend, commandName, argsBuilder(cfg, targetArg))
+		invocation = legacyBackendInvocation(cfg, commandName, argsBuilder(cfg, targetArg))
 	}
 	if invocation.BackendName != "" {
 		cfg.Backend = invocation.BackendName

--- a/code-dispatcher/executor.go
+++ b/code-dispatcher/executor.go
@@ -571,45 +571,6 @@ func getStatusSymbols() (success, warning, failed string) {
 	return "✓", "⚠️", "✗"
 }
 
-func buildCodexArgs(cfg *Config, targetArg string) []string {
-	if cfg == nil {
-		panic("buildCodexArgs: nil config")
-	}
-
-	var resumeSessionID string
-	isResume := cfg.Mode == "resume"
-	if isResume {
-		resumeSessionID = strings.TrimSpace(cfg.SessionID)
-		if resumeSessionID == "" {
-			logError("invalid config: resume mode requires non-empty session_id")
-			isResume = false
-		}
-	}
-
-	args := []string{"e"}
-
-	if model := resolveBackendModel("codex"); model != "" {
-		args = append(args, "-m", model)
-	}
-
-	args = append(args, "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check")
-
-	if isResume {
-		return append(args,
-			"--json",
-			"resume",
-			resumeSessionID,
-			targetArg,
-		)
-	}
-
-	return append(args,
-		"-C", cfg.WorkDir,
-		"--json",
-		targetArg,
-	)
-}
-
 func runTask(taskSpec TaskSpec, silent bool, timeoutSec int) TaskResult {
 	return runTaskWithContext(context.Background(), taskSpec, nil, nil, false, silent, timeoutSec)
 }
@@ -637,8 +598,6 @@ func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Ba
 	commandName := backendCommand
 	argsBuilder := buildArgsFn
 	if backend != nil {
-		commandName = backend.Command()
-		argsBuilder = backend.BuildArgs
 		cfg.Backend = backend.Name()
 	} else if taskSpec.Backend != "" {
 		cfg.Backend = taskSpec.Backend
@@ -659,21 +618,26 @@ func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Ba
 		return result
 	}
 
-	backendEnv := runtimeEnvForBackend(cfg.Backend)
-	backendEnvUnsetKeys := runtimeUnsetEnvKeysForBackend(cfg.Backend)
-
 	useStdin := taskSpec.UseStdin
 	targetArg := taskSpec.Task
 	if useStdin {
 		targetArg = "-"
 	}
 
-	var backendArgs []string
-	if useCustomArgs {
-		backendArgs = customArgs
-	} else {
-		backendArgs = argsBuilder(cfg, targetArg)
+	invocation := BackendInvocation{}
+	switch {
+	case useCustomArgs:
+		invocation = legacyBackendInvocation(cfg.Backend, commandName, customArgs)
+	case backend != nil:
+		invocation = backend.BuildInvocation(cfg, targetArg)
+	default:
+		invocation = legacyBackendInvocation(cfg.Backend, commandName, argsBuilder(cfg, targetArg))
 	}
+	if invocation.BackendName != "" {
+		cfg.Backend = invocation.BackendName
+	}
+	commandName = invocation.Command
+	backendArgs := invocation.Args
 
 	prefixMsg := func(msg string) string {
 		if taskSpec.ID == "" {
@@ -765,17 +729,15 @@ func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Ba
 
 	cmd := newCommandRunner(ctx, commandName, backendArgs...)
 
-	if len(backendEnv) > 0 {
-		cmd.SetEnv(backendEnv)
+	if len(invocation.Env) > 0 {
+		cmd.SetEnv(invocation.Env)
 	}
-	if len(backendEnvUnsetKeys) > 0 {
-		cmd.UnsetEnv(backendEnvUnsetKeys)
+	if len(invocation.UnsetEnvKeys) > 0 {
+		cmd.UnsetEnv(invocation.UnsetEnvKeys)
 	}
 
-	// For backends that don't support -C flag (claude), set working directory via cmd.Dir.
-	// Codex passes workdir via -C flag, so we skip setting Dir for it to avoid conflicts
-	if commandName != "codex" && cfg.WorkDir != "" && cfg.Mode != "resume" {
-		cmd.SetDir(cfg.WorkDir)
+	if invocation.WorkDir != "" {
+		cmd.SetDir(invocation.WorkDir)
 	}
 
 	stderrWriters := []io.Writer{stderrBuf}
@@ -786,8 +748,8 @@ func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Ba
 	var stderrFilter *filteringWriter
 	if !silent {
 		stderrOut := io.Writer(os.Stderr)
-		if cfg.Backend == "codex" {
-			stderrFilter = newFilteringWriter(os.Stderr, codexNoisePatterns)
+		if len(invocation.StderrFilterPatterns) > 0 {
+			stderrFilter = newFilteringWriter(os.Stderr, invocation.StderrFilterPatterns)
 			stderrOut = stderrFilter
 		}
 		stderrWriters = append([]io.Writer{stderrOut}, stderrWriters...)
@@ -837,7 +799,11 @@ func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Ba
 	completeSeen := make(chan struct{}, 1)
 	parseCh := make(chan parseResult, 1)
 	go func() {
-		msg, tid := parseBackendStreamInternal(stdoutReader, cfg.Backend, logWarnFn, logInfoFn, func() {
+		parseStream := invocation.ParseStream
+		if parseStream == nil {
+			parseStream = parseStreamForBackend(cfg.Backend)
+		}
+		msg, tid := parseStream(stdoutReader, logWarnFn, logInfoFn, func() {
 			select {
 			case messageSeen <- struct{}{}:
 			default:

--- a/code-dispatcher/executor_concurrent_test.go
+++ b/code-dispatcher/executor_concurrent_test.go
@@ -314,11 +314,11 @@ func TestExecutorHelperCoverage(t *testing.T) {
 		}
 
 		args := buildCodexArgs(&Config{Mode: "new", WorkDir: "/tmp"}, "task")
-		if !slices.Equal(args, []string{"e", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/tmp", "--json", "task"}) {
+		if !slices.Equal(args, []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/tmp", "--json", "task"}) {
 			t.Fatalf("unexpected codex args: %+v", args)
 		}
 		args = buildCodexArgs(&Config{Mode: "resume", SessionID: "sess"}, "target")
-		if !slices.Equal(args, []string{"e", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "--json", "resume", "sess", "target"}) {
+		if !slices.Equal(args, []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "--json", "resume", "sess", "target"}) {
 			t.Fatalf("unexpected resume args: %+v", args)
 		}
 	})

--- a/code-dispatcher/executor_concurrent_test.go
+++ b/code-dispatcher/executor_concurrent_test.go
@@ -669,6 +669,34 @@ func TestExecutorRunTaskWithContext(t *testing.T) {
 		}
 	})
 
+	t.Run("legacyClaudeInvocationSetsDir", func(t *testing.T) {
+		origCommand := backendCommand
+		origBuildArgs := buildArgsFn
+		backendCommand = "claude"
+		buildArgsFn = buildClaudeArgs
+		t.Cleanup(func() {
+			backendCommand = origCommand
+			buildArgsFn = origBuildArgs
+		})
+
+		var rc *execFakeRunner
+		newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
+			rc = &execFakeRunner{
+				stdout:  newReasonReadCloser(`{"type":"result","subtype":"success","session_id":"sid","is_error":false,"result":"ok"}`),
+				process: &execFakeProcess{pid: 16},
+			}
+			return rc
+		}
+
+		res := runTaskWithContext(context.Background(), TaskSpec{ID: "task-legacy", Task: "payload", WorkDir: "/tmp", Backend: "claude"}, nil, nil, false, false, 1)
+		if res.ExitCode != 0 || res.Message != "ok" {
+			t.Fatalf("unexpected result: %+v", res)
+		}
+		if rc == nil || rc.dir != "/tmp" {
+			t.Fatalf("expected legacy claude invocation to set cmd.Dir, got runner=%v dir=%q", rc, rc.dir)
+		}
+	})
+
 	t.Run("claudeBackendUnsetsNestedSessionEnvMarker", func(t *testing.T) {
 		setRuntimeSettingsForTest(map[string]string{
 			"CLAUDECODE":        "1",

--- a/code-dispatcher/main.go
+++ b/code-dispatcher/main.go
@@ -414,6 +414,7 @@ func run() (exitCode int) {
 		WorkDir:   cfg.WorkDir,
 		Mode:      cfg.Mode,
 		SessionID: cfg.SessionID,
+		Backend:   cfg.Backend,
 		UseStdin:  useStdin,
 	}
 

--- a/code-dispatcher/main_test.go
+++ b/code-dispatcher/main_test.go
@@ -1657,8 +1657,10 @@ func TestRun_DefaultPromptInjectionPrefixesTask(t *testing.T) {
 			}
 
 			var gotTask string
+			var gotBackend string
 			runTaskFn = func(task TaskSpec, silent bool, timeout int) TaskResult {
 				gotTask = task.Task
+				gotBackend = task.Backend
 				return TaskResult{ExitCode: 0, Message: "ok"}
 			}
 
@@ -1692,6 +1694,9 @@ func TestRun_DefaultPromptInjectionPrefixesTask(t *testing.T) {
 			}
 			if gotTask != wantTask {
 				t.Fatalf("task mismatch:\n got=%q\nwant=%q", gotTask, wantTask)
+			}
+			if gotBackend != tt.backend {
+				t.Fatalf("backend = %q, want %q", gotBackend, tt.backend)
 			}
 		})
 	}

--- a/code-dispatcher/main_test.go
+++ b/code-dispatcher/main_test.go
@@ -89,6 +89,15 @@ func (t testBackend) Command() string {
 	return "echo"
 }
 
+func (t testBackend) BuildInvocation(cfg *Config, targetArg string) BackendInvocation {
+	return BackendInvocation{
+		BackendName: t.Name(),
+		Command:     t.Command(),
+		Args:        t.BuildArgs(cfg, targetArg),
+		ParseStream: parseStreamForBackend(t.Name()),
+	}
+}
+
 func withBackend(command string, argsFn func(*Config, string) []string) func() {
 	prev := selectBackendFn
 	selectBackendFn = func(name string) (Backend, error) {
@@ -1692,7 +1701,7 @@ func TestRunBuildCodexArgs_NewMode(t *testing.T) {
 	cfg := &Config{Mode: "new", WorkDir: "/test/dir"}
 	args := buildCodexArgs(cfg, "my task")
 	expected := []string{
-		"e",
+		"exec",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--skip-git-repo-check",
 		"-C", "/test/dir",
@@ -1713,7 +1722,7 @@ func TestRunBuildCodexArgs_ResumeMode(t *testing.T) {
 	cfg := &Config{Mode: "resume", SessionID: "session-abc"}
 	args := buildCodexArgs(cfg, "-")
 	expected := []string{
-		"e",
+		"exec",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--skip-git-repo-check",
 		"--json",
@@ -1734,7 +1743,7 @@ func TestRunBuildCodexArgs_ResumeMode(t *testing.T) {
 func TestRunBuildCodexArgs_ResumeMode_EmptySessionHandledGracefully(t *testing.T) {
 	cfg := &Config{Mode: "resume", SessionID: "   ", WorkDir: "/test/dir"}
 	args := buildCodexArgs(cfg, "task")
-	expected := []string{"e", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/test/dir", "--json", "task"}
+	expected := []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/test/dir", "--json", "task"}
 	if len(args) != len(expected) {
 		t.Fatalf("len mismatch")
 	}
@@ -1811,7 +1820,7 @@ func TestBackendBuildArgs_CodexBackend(t *testing.T) {
 	cfg := &Config{Mode: "new", WorkDir: "/test/dir"}
 	got := backend.BuildArgs(cfg, "task")
 	want := []string{
-		"e",
+		"exec",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--skip-git-repo-check",
 		"-C", "/test/dir",


### PR DESCRIPTION
## Summary by Sourcery

Introduce a unified backend invocation policy object and migrate codex/claude execution paths to use it while tightening their environment, working directory, stderr filtering, and stream parsing behavior.

New Features:
- Add BackendInvocation struct and BackendStreamParser to encapsulate backend command, arguments, environment, working directory, stderr filtering, and stream parsing policy.
- Extend Backend interface and test backend to support building full invocation descriptions rather than just argument lists.

Enhancements:
- Refine codex backend behavior to use the explicit 'exec' subcommand and centralize its arg-building logic in backend.go.
- Update executor to construct and execute commands via BackendInvocation, including custom-arg and legacy backend paths, and to drive parsing through backend-specific stream parsers.
- Adjust Claude backend to control workdir and environment-unset policy internally instead of relying on executor heuristics.
- Factor runtime environment injection and backend-specific stderr filtering into reusable helpers and legacy invocation helpers.

Tests:
- Add BackendInvocation policy tests for codex and claude backends, including env filtering, workdir handling, stderr filtering, and stream parsing hooks.
- Update existing codex argument construction tests across backend, main, and concurrent executor tests to reflect the new 'exec' subcommand and shared helper location.

---

Linked issue: Closes #42
