### PR TITLE
refactor: extract serial invocation planner

### DIFF
--- a/code-dispatcher/main.go
+++ b/code-dispatcher/main.go
@@ -332,7 +332,7 @@ func run() (exitCode int) {
 	fmt.Fprintf(os.Stderr, "  PID: %d\n", os.Getpid())
 	fmt.Fprintf(os.Stderr, "  Log: %s\n", logger.Path())
 
-	if plan.UseStdin && len(plan.Reasons) > 0 {
+	if plan.TaskSpec.UseStdin && len(plan.Reasons) > 0 {
 		logWarn(fmt.Sprintf("Using stdin mode for task due to: %s", strings.Join(plan.Reasons, ", ")))
 	}
 

--- a/code-dispatcher/main.go
+++ b/code-dispatcher/main.go
@@ -315,110 +315,30 @@ func run() (exitCode int) {
 	logInfo(fmt.Sprintf("Timeout: %ds", timeoutSec))
 	cfg.Timeout = timeoutSec
 
-	var taskText string
-	var piped bool
-
 	if cfg.ExplicitStdin {
 		logInfo("Explicit stdin mode: reading task from stdin")
-		data, err := io.ReadAll(stdinReader)
-		if err != nil {
-			logError("Failed to read stdin: " + err.Error())
-			return 1
-		}
-		taskText = string(data)
-		if taskText == "" {
-			logError("Explicit stdin mode requires task input from stdin")
-			return 1
-		}
-		piped = !isTerminal()
-	} else {
-		pipedTask, err := readPipedTask()
-		if err != nil {
-			logError("Failed to read piped stdin: " + err.Error())
-			return 1
-		}
-		piped = pipedTask != ""
-		if piped {
-			taskText = pipedTask
-		} else {
-			taskText = cfg.Task
-		}
 	}
 
-	promptFile := defaultPromptFileForBackend(cfg.Backend)
-	if promptFile != "" {
-		prompt, err := readAgentPromptFile(promptFile)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				logWarn("Failed to read prompt file: " + err.Error())
-			}
-		} else if strings.TrimSpace(prompt) != "" {
-			taskText = wrapTaskWithAgentPrompt(prompt, taskText)
-		}
+	plan, err := planSerialInvocation(cfg, backend)
+	if err != nil {
+		logError(err.Error())
+		return 1
 	}
-
-	requestedStdin := cfg.ExplicitStdin || shouldUseStdin(taskText, piped)
-	useStdin := requestedStdin
-
-	targetArg := taskText
-	if useStdin {
-		targetArg = "-"
-	}
-	backendArgs := buildArgsFn(cfg, targetArg)
 
 	// Print startup information to stderr
 	fmt.Fprintf(os.Stderr, "[%s]\n", name)
 	fmt.Fprintf(os.Stderr, "  Backend: %s\n", cfg.Backend)
-	fmt.Fprintf(os.Stderr, "  Command: %s %s\n", backendCommand, strings.Join(backendArgs, " "))
+	fmt.Fprintf(os.Stderr, "  Command: %s %s\n", plan.Invocation.Command, strings.Join(plan.Invocation.Args, " "))
 	fmt.Fprintf(os.Stderr, "  PID: %d\n", os.Getpid())
 	fmt.Fprintf(os.Stderr, "  Log: %s\n", logger.Path())
 
-	if useStdin {
-		var reasons []string
-		if piped {
-			reasons = append(reasons, "piped input")
-		}
-		if cfg.ExplicitStdin {
-			reasons = append(reasons, "explicit \"-\"")
-		}
-		if strings.Contains(taskText, "\n") {
-			reasons = append(reasons, "newline")
-		}
-		if strings.Contains(taskText, "\\") {
-			reasons = append(reasons, "backslash")
-		}
-		if strings.Contains(taskText, "\"") {
-			reasons = append(reasons, "double-quote")
-		}
-		if strings.Contains(taskText, "'") {
-			reasons = append(reasons, "single-quote")
-		}
-		if strings.Contains(taskText, "`") {
-			reasons = append(reasons, "backtick")
-		}
-		if strings.Contains(taskText, "$") {
-			reasons = append(reasons, "dollar")
-		}
-		if len(taskText) > 800 {
-			reasons = append(reasons, "length>800")
-		}
-		if len(reasons) > 0 {
-			logWarn(fmt.Sprintf("Using stdin mode for task due to: %s", strings.Join(reasons, ", ")))
-		}
+	if plan.UseStdin && len(plan.Reasons) > 0 {
+		logWarn(fmt.Sprintf("Using stdin mode for task due to: %s", strings.Join(plan.Reasons, ", ")))
 	}
 
 	logInfo(fmt.Sprintf("%s running...", cfg.Backend))
 
-	taskSpec := TaskSpec{
-		Task:      taskText,
-		WorkDir:   cfg.WorkDir,
-		Mode:      cfg.Mode,
-		SessionID: cfg.SessionID,
-		Backend:   cfg.Backend,
-		UseStdin:  useStdin,
-	}
-
-	result := runTaskFn(taskSpec, false, cfg.Timeout)
+	result := runTaskFn(plan.TaskSpec, false, cfg.Timeout)
 
 	if result.ExitCode != 0 {
 		return result.ExitCode

--- a/code-dispatcher/main_test.go
+++ b/code-dispatcher/main_test.go
@@ -3857,7 +3857,7 @@ func TestRun_ExplicitStdinReadError(t *testing.T) {
 	if exitCode != 1 {
 		t.Fatalf("exit code %d, want 1", exitCode)
 	}
-	if !strings.Contains(logOutput, "Failed to read stdin: broken stdin") {
+	if !strings.Contains(logOutput, "failed to read stdin: broken stdin") {
 		t.Fatalf("log missing read error entry, got %q", logOutput)
 	}
 	// Log file is always removed after completion (new behavior)
@@ -3955,7 +3955,7 @@ func TestRun_PipedTaskReadError(t *testing.T) {
 	if exitCode != 1 {
 		t.Fatalf("exit=%d, want 1", exitCode)
 	}
-	if !strings.Contains(logOutput, "Failed to read piped stdin: read stdin: pipe failure") {
+	if !strings.Contains(logOutput, "failed to read piped stdin: read stdin: pipe failure") {
 		t.Fatalf("log missing piped read error, got %q", logOutput)
 	}
 	// Log file is always removed after completion (new behavior)

--- a/code-dispatcher/serial_invocation_planner.go
+++ b/code-dispatcher/serial_invocation_planner.go
@@ -10,7 +10,6 @@ import (
 type serialInvocationPlan struct {
 	Invocation BackendInvocation
 	TaskSpec   TaskSpec
-	UseStdin   bool
 	Reasons    []string
 }
 
@@ -51,27 +50,26 @@ func planSerialInvocation(cfg *Config, backend Backend) (*serialInvocationPlan, 
 	return &serialInvocationPlan{
 		Invocation: invocation,
 		TaskSpec:   taskSpec,
-		UseStdin:   useStdin,
 		Reasons:    serialStdinReasons(taskText, piped, cfg.ExplicitStdin),
 	}, nil
 }
 
-func resolveSerialTaskText(cfg *Config) (taskText string, piped bool, err error) {
+func resolveSerialTaskText(cfg *Config) (string, bool, error) {
 	if cfg.ExplicitStdin {
 		data, err := io.ReadAll(stdinReader)
 		if err != nil {
-			return "", false, fmt.Errorf("Failed to read stdin: %w", err)
+			return "", false, fmt.Errorf("failed to read stdin: %w", err)
 		}
-		taskText = string(data)
+		taskText := string(data)
 		if taskText == "" {
-			return "", false, fmt.Errorf("Explicit stdin mode requires task input from stdin")
+			return "", false, fmt.Errorf("explicit stdin mode requires task input from stdin")
 		}
 		return taskText, !isTerminal(), nil
 	}
 
 	pipedTask, err := readPipedTask()
 	if err != nil {
-		return "", false, fmt.Errorf("Failed to read piped stdin: %w", err)
+		return "", false, fmt.Errorf("failed to read piped stdin: %w", err)
 	}
 	if pipedTask != "" {
 		return pipedTask, true, nil

--- a/code-dispatcher/serial_invocation_planner.go
+++ b/code-dispatcher/serial_invocation_planner.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type serialInvocationPlan struct {
+	Invocation BackendInvocation
+	TaskSpec   TaskSpec
+	UseStdin   bool
+	Reasons    []string
+}
+
+func planSerialInvocation(cfg *Config, backend Backend) (*serialInvocationPlan, error) {
+	taskText, piped, err := resolveSerialTaskText(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	promptFile := defaultPromptFileForBackend(cfg.Backend)
+	if promptFile != "" {
+		prompt, err := readAgentPromptFile(promptFile)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				logWarn("Failed to read prompt file: " + err.Error())
+			}
+		} else if strings.TrimSpace(prompt) != "" {
+			taskText = wrapTaskWithAgentPrompt(prompt, taskText)
+		}
+	}
+
+	useStdin := cfg.ExplicitStdin || shouldUseStdin(taskText, piped)
+	targetArg := taskText
+	if useStdin {
+		targetArg = "-"
+	}
+
+	invocation := backend.BuildInvocation(cfg, targetArg)
+	taskSpec := TaskSpec{
+		Task:      taskText,
+		WorkDir:   cfg.WorkDir,
+		Mode:      cfg.Mode,
+		SessionID: cfg.SessionID,
+		Backend:   cfg.Backend,
+		UseStdin:  useStdin,
+	}
+
+	return &serialInvocationPlan{
+		Invocation: invocation,
+		TaskSpec:   taskSpec,
+		UseStdin:   useStdin,
+		Reasons:    serialStdinReasons(taskText, piped, cfg.ExplicitStdin),
+	}, nil
+}
+
+func resolveSerialTaskText(cfg *Config) (taskText string, piped bool, err error) {
+	if cfg.ExplicitStdin {
+		data, err := io.ReadAll(stdinReader)
+		if err != nil {
+			return "", false, fmt.Errorf("Failed to read stdin: %w", err)
+		}
+		taskText = string(data)
+		if taskText == "" {
+			return "", false, fmt.Errorf("Explicit stdin mode requires task input from stdin")
+		}
+		return taskText, !isTerminal(), nil
+	}
+
+	pipedTask, err := readPipedTask()
+	if err != nil {
+		return "", false, fmt.Errorf("Failed to read piped stdin: %w", err)
+	}
+	if pipedTask != "" {
+		return pipedTask, true, nil
+	}
+	return cfg.Task, false, nil
+}
+
+func serialStdinReasons(taskText string, piped bool, explicitStdin bool) []string {
+	var reasons []string
+	if piped {
+		reasons = append(reasons, "piped input")
+	}
+	if explicitStdin {
+		reasons = append(reasons, "explicit \"-\"")
+	}
+	if strings.Contains(taskText, "\n") {
+		reasons = append(reasons, "newline")
+	}
+	if strings.Contains(taskText, "\\") {
+		reasons = append(reasons, "backslash")
+	}
+	if strings.Contains(taskText, "\"") {
+		reasons = append(reasons, "double-quote")
+	}
+	if strings.Contains(taskText, "'") {
+		reasons = append(reasons, "single-quote")
+	}
+	if strings.Contains(taskText, "`") {
+		reasons = append(reasons, "backtick")
+	}
+	if strings.Contains(taskText, "$") {
+		reasons = append(reasons, "dollar")
+	}
+	if len(taskText) > 800 {
+		reasons = append(reasons, "length>800")
+	}
+	return reasons
+}

--- a/code-dispatcher/serial_invocation_planner_test.go
+++ b/code-dispatcher/serial_invocation_planner_test.go
@@ -129,8 +129,53 @@ func TestPlanSerialInvocationInjectsDefaultPrompt(t *testing.T) {
 	if !plan.TaskSpec.UseStdin {
 		t.Fatalf("prompt-wrapped task should use stdin")
 	}
+	if !hasSerialReason(plan.Reasons, "newline") {
+		t.Fatalf("Reasons = %v, want newline reason from wrapped prompt", plan.Reasons)
+	}
 	if got := plan.Invocation.Args[len(plan.Invocation.Args)-1]; got != "-" {
 		t.Fatalf("last arg = %q, want stdin target", got)
+	}
+}
+
+func TestSerialStdinReasons(t *testing.T) {
+	tests := []struct {
+		name          string
+		task          string
+		piped         bool
+		explicitStdin bool
+		want          []string
+	}{
+		{
+			name: "no reasons",
+			task: "plain task",
+			want: nil,
+		},
+		{
+			name:          "piped and explicit",
+			task:          "plain task",
+			piped:         true,
+			explicitStdin: true,
+			want:          []string{"piped input", `explicit "-"`},
+		},
+		{
+			name: "special characters",
+			task: "line1\npath\\file \"quote\" 'single' `tick` $HOME",
+			want: []string{"newline", "backslash", "double-quote", "single-quote", "backtick", "dollar"},
+		},
+		{
+			name: "length threshold",
+			task: strings.Repeat("x", 801),
+			want: []string{"length>800"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := serialStdinReasons(tt.task, tt.piped, tt.explicitStdin)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("serialStdinReasons(%q, piped=%v, explicit=%v) = %v, want %v", tt.task, tt.piped, tt.explicitStdin, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/code-dispatcher/serial_invocation_planner_test.go
+++ b/code-dispatcher/serial_invocation_planner_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPlanSerialInvocationInlineCodexPreview(t *testing.T) {
+	defer resetTestHooks()
+	useEmptyPromptHome(t)
+	stdinReader = strings.NewReader("")
+	isTerminalFn = func() bool { return true }
+
+	cfg := &Config{Mode: "new", Task: "do work", WorkDir: "/repo", Backend: "codex", Timeout: 9}
+	plan, err := planSerialInvocation(cfg, CodexBackend{})
+	if err != nil {
+		t.Fatalf("planSerialInvocation: %v", err)
+	}
+
+	if plan.TaskSpec.Task != "do work" || plan.TaskSpec.UseStdin {
+		t.Fatalf("TaskSpec = %+v", plan.TaskSpec)
+	}
+	if plan.TaskSpec.Backend != "codex" {
+		t.Fatalf("TaskSpec.Backend = %q, want codex", plan.TaskSpec.Backend)
+	}
+	wantArgs := []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", "/repo", "--json", "do work"}
+	if plan.Invocation.Command != "codex" || !reflect.DeepEqual(plan.Invocation.Args, wantArgs) {
+		t.Fatalf("invocation = %s %v, want codex %v", plan.Invocation.Command, plan.Invocation.Args, wantArgs)
+	}
+}
+
+func TestPlanSerialInvocationExplicitStdin(t *testing.T) {
+	defer resetTestHooks()
+	useEmptyPromptHome(t)
+	stdinReader = strings.NewReader("stdin task")
+	isTerminalFn = func() bool { return true }
+
+	cfg := &Config{Mode: "new", Task: "-", WorkDir: "/repo", Backend: "codex", ExplicitStdin: true}
+	plan, err := planSerialInvocation(cfg, CodexBackend{})
+	if err != nil {
+		t.Fatalf("planSerialInvocation: %v", err)
+	}
+
+	if plan.TaskSpec.Task != "stdin task" || !plan.TaskSpec.UseStdin {
+		t.Fatalf("TaskSpec = %+v", plan.TaskSpec)
+	}
+	if !hasSerialReason(plan.Reasons, `explicit "-"`) {
+		t.Fatalf("Reasons = %v, want explicit stdin reason", plan.Reasons)
+	}
+	if got := plan.Invocation.Args[len(plan.Invocation.Args)-1]; got != "-" {
+		t.Fatalf("last arg = %q, want stdin target", got)
+	}
+}
+
+func TestPlanSerialInvocationPipedInput(t *testing.T) {
+	defer resetTestHooks()
+	useEmptyPromptHome(t)
+	stdinReader = strings.NewReader("piped task")
+	isTerminalFn = func() bool { return false }
+
+	cfg := &Config{Mode: "new", Task: "ignored", WorkDir: "/repo", Backend: "codex"}
+	plan, err := planSerialInvocation(cfg, CodexBackend{})
+	if err != nil {
+		t.Fatalf("planSerialInvocation: %v", err)
+	}
+
+	if plan.TaskSpec.Task != "piped task" || !plan.TaskSpec.UseStdin {
+		t.Fatalf("TaskSpec = %+v", plan.TaskSpec)
+	}
+	if !hasSerialReason(plan.Reasons, "piped input") {
+		t.Fatalf("Reasons = %v, want piped input reason", plan.Reasons)
+	}
+	if got := plan.Invocation.Args[len(plan.Invocation.Args)-1]; got != "-" {
+		t.Fatalf("last arg = %q, want stdin target", got)
+	}
+}
+
+func TestPlanSerialInvocationResumePreviewUsesBackendPolicy(t *testing.T) {
+	defer resetTestHooks()
+	useEmptyPromptHome(t)
+	stdinReader = strings.NewReader("")
+	isTerminalFn = func() bool { return true }
+
+	cfg := &Config{Mode: "resume", SessionID: "sid", Task: "continue", WorkDir: "/repo", Backend: "codex"}
+	plan, err := planSerialInvocation(cfg, CodexBackend{})
+	if err != nil {
+		t.Fatalf("planSerialInvocation: %v", err)
+	}
+
+	wantArgs := []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "--json", "resume", "sid", "continue"}
+	if !reflect.DeepEqual(plan.Invocation.Args, wantArgs) {
+		t.Fatalf("args = %v, want %v", plan.Invocation.Args, wantArgs)
+	}
+	if plan.TaskSpec.Mode != "resume" || plan.TaskSpec.SessionID != "sid" {
+		t.Fatalf("TaskSpec = %+v", plan.TaskSpec)
+	}
+}
+
+func TestPlanSerialInvocationInjectsDefaultPrompt(t *testing.T) {
+	defer resetTestHooks()
+	stdinReader = strings.NewReader("")
+	isTerminalFn = func() bool { return true }
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	promptPath := filepath.Join(home, ".code-dispatcher", "prompts", "codex-prompt.md")
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(promptPath, []byte("PROMPT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg := &Config{Mode: "new", Task: "do", WorkDir: "/repo", Backend: "codex"}
+	plan, err := planSerialInvocation(cfg, CodexBackend{})
+	if err != nil {
+		t.Fatalf("planSerialInvocation: %v", err)
+	}
+
+	wantTask := "<agent-prompt>\nPROMPT\n</agent-prompt>\n\ndo"
+	if plan.TaskSpec.Task != wantTask {
+		t.Fatalf("task = %q, want %q", plan.TaskSpec.Task, wantTask)
+	}
+	if !plan.TaskSpec.UseStdin {
+		t.Fatalf("prompt-wrapped task should use stdin")
+	}
+	if got := plan.Invocation.Args[len(plan.Invocation.Args)-1]; got != "-" {
+		t.Fatalf("last arg = %q, want stdin target", got)
+	}
+}
+
+func hasSerialReason(reasons []string, want string) bool {
+	for _, reason := range reasons {
+		if reason == want {
+			return true
+		}
+	}
+	return false
+}
+
+func useEmptyPromptHome(t *testing.T) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}


### PR DESCRIPTION
## Summary by Sourcery

Extract serial invocation planning into a dedicated planner and update main execution flow to use it

Enhancements:
- Introduce a reusable serial invocation planner that encapsulates task text resolution, stdin policy, default prompt injection, and backend invocation construction
- Refine TaskSpec to carry backend information and centralize stdin decision reasoning for logging
- Update main dispatcher to consume the new planner’s plan structure instead of constructing backend arguments and TaskSpec inline

Tests:
- Add unit tests covering serial invocation planning across explicit stdin, piped input, default prompt injection, and resume mode behavior

---

Linked issue: Closes #44
