### PR TITLE
refactor: extract parallel run module

### DIFF
--- a/code-dispatcher/main.go
+++ b/code-dispatcher/main.go
@@ -168,117 +168,15 @@ func run() (exitCode int) {
 
 	// Handle remaining commands
 	if len(os.Args) > 1 {
-		args := os.Args[1:]
-		parallelIndex := -1
-		for i, arg := range args {
-			if arg == "--parallel" {
-				parallelIndex = i
-				break
+		outcome := runParallelInvocation(name, os.Args[1:])
+		if outcome.Handled {
+			if outcome.Stderr != "" {
+				fmt.Fprint(os.Stderr, outcome.Stderr)
 			}
-		}
-
-		if parallelIndex != -1 {
-			backendName := ""
-			backendSpecified := false
-			fullOutput := false
-			var extras []string
-
-			for i := 0; i < len(args); i++ {
-				arg := args[i]
-				switch {
-				case arg == "--parallel":
-					continue
-				case arg == "--full-output":
-					fullOutput = true
-				case arg == "--backend":
-					if i+1 >= len(args) {
-						fmt.Fprintln(os.Stderr, "ERROR: --backend flag requires a value")
-						return 1
-					}
-					value := strings.TrimSpace(args[i+1])
-					if value == "" {
-						fmt.Fprintln(os.Stderr, "ERROR: --backend flag requires a value")
-						return 1
-					}
-					backendName = value
-					backendSpecified = true
-					i++
-				case strings.HasPrefix(arg, "--backend="):
-					value := strings.TrimSpace(strings.TrimPrefix(arg, "--backend="))
-					if value == "" {
-						fmt.Fprintln(os.Stderr, "ERROR: --backend flag requires a value")
-						return 1
-					}
-					backendName = value
-					backendSpecified = true
-				default:
-					extras = append(extras, arg)
-				}
+			if outcome.Stdout != "" {
+				fmt.Print(outcome.Stdout)
 			}
-
-			if len(extras) > 0 {
-				fmt.Fprintln(os.Stderr, "ERROR: --parallel reads its task configuration from stdin; only --backend and --full-output are allowed.")
-				fmt.Fprintln(os.Stderr, "Usage examples:")
-				fmt.Fprintf(os.Stderr, "  %s --parallel --backend codex < tasks.txt\n", name)
-				fmt.Fprintf(os.Stderr, "  echo '...' | %s --parallel --backend claude\n", name)
-				return 1
-			}
-
-			if !backendSpecified {
-				fmt.Fprintf(os.Stderr, "ERROR: --backend is required in --parallel mode (supported: %s)\n", supportedBackendNamesText())
-				fmt.Fprintln(os.Stderr, "Usage examples:")
-				fmt.Fprintf(os.Stderr, "  %s --parallel --backend codex < tasks.txt\n", name)
-				fmt.Fprintf(os.Stderr, "  %s --parallel --backend claude <<'EOF'\n", name)
-				return 1
-			}
-
-			backend, err := selectBackendFn(backendName)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-				return 1
-			}
-			backendName = backend.Name()
-
-			data, err := io.ReadAll(stdinReader)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "ERROR: failed to read stdin: %v\n", err)
-				return 1
-			}
-
-			cfg, err := parseParallelConfig(data)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-				return 1
-			}
-
-			cfg.GlobalBackend = backendName
-			for i := range cfg.Tasks {
-				if strings.TrimSpace(cfg.Tasks[i].Backend) == "" {
-					cfg.Tasks[i].Backend = backendName
-				}
-			}
-
-			timeoutSec := resolveTimeout()
-			layers, err := topologicalSort(cfg.Tasks)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-				return 1
-			}
-
-			results := executeConcurrent(layers, timeoutSec)
-
-			// Default: summary mode (context-efficient)
-			// --full-output: legacy full output mode
-			fmt.Println(generateFinalOutputWithMode(results, !fullOutput))
-
-			exitCode = 0
-			for _, res := range results {
-				if res.ExitCode != 0 {
-					exitCode = res.ExitCode
-				}
-			}
-
-			return exitCode
+			return outcome.ExitCode
 		}
 	}
 

--- a/code-dispatcher/parallel_run.go
+++ b/code-dispatcher/parallel_run.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type parallelRunOutcome struct {
+	Handled  bool
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+func runParallelInvocation(dispatcherName string, args []string) parallelRunOutcome {
+	if !hasParallelFlag(args) {
+		return parallelRunOutcome{}
+	}
+
+	backendName := ""
+	backendSpecified := false
+	fullOutput := false
+	var extras []string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--parallel":
+			continue
+		case arg == "--full-output":
+			fullOutput = true
+		case arg == "--backend":
+			if i+1 >= len(args) {
+				return parallelErrorOutcome("--backend flag requires a value")
+			}
+			value := strings.TrimSpace(args[i+1])
+			if value == "" {
+				return parallelErrorOutcome("--backend flag requires a value")
+			}
+			backendName = value
+			backendSpecified = true
+			i++
+		case strings.HasPrefix(arg, "--backend="):
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--backend="))
+			if value == "" {
+				return parallelErrorOutcome("--backend flag requires a value")
+			}
+			backendName = value
+			backendSpecified = true
+		default:
+			extras = append(extras, arg)
+		}
+	}
+
+	if len(extras) > 0 {
+		var stderr strings.Builder
+		fmt.Fprintln(&stderr, "ERROR: --parallel reads its task configuration from stdin; only --backend and --full-output are allowed.")
+		fmt.Fprintln(&stderr, "Usage examples:")
+		fmt.Fprintf(&stderr, "  %s --parallel --backend codex < tasks.txt\n", dispatcherName)
+		fmt.Fprintf(&stderr, "  echo '...' | %s --parallel --backend claude\n", dispatcherName)
+		return parallelRunOutcome{Handled: true, ExitCode: 1, Stderr: stderr.String()}
+	}
+
+	if !backendSpecified {
+		var stderr strings.Builder
+		fmt.Fprintln(&stderr, "ERROR: --backend is required in --parallel mode (supported: codex, claude)")
+		fmt.Fprintln(&stderr, "Usage examples:")
+		fmt.Fprintf(&stderr, "  %s --parallel --backend codex < tasks.txt\n", dispatcherName)
+		fmt.Fprintf(&stderr, "  %s --parallel --backend claude <<'EOF'\n", dispatcherName)
+		return parallelRunOutcome{Handled: true, ExitCode: 1, Stderr: stderr.String()}
+	}
+
+	backend, err := selectBackendFn(backendName)
+	if err != nil {
+		return parallelErrorOutcome(err.Error())
+	}
+	backendName = backend.Name()
+
+	data, err := io.ReadAll(stdinReader)
+	if err != nil {
+		return parallelErrorOutcome(fmt.Sprintf("failed to read stdin: %v", err))
+	}
+
+	cfg, err := parseParallelConfig(data)
+	if err != nil {
+		return parallelErrorOutcome(err.Error())
+	}
+
+	cfg.GlobalBackend = backendName
+	for i := range cfg.Tasks {
+		if strings.TrimSpace(cfg.Tasks[i].Backend) == "" {
+			cfg.Tasks[i].Backend = backendName
+		}
+	}
+
+	timeoutSec := resolveTimeout()
+	layers, err := topologicalSort(cfg.Tasks)
+	if err != nil {
+		return parallelErrorOutcome(err.Error())
+	}
+
+	results := executeConcurrent(layers, timeoutSec)
+	output := generateFinalOutputWithMode(results, !fullOutput)
+
+	return parallelRunOutcome{
+		Handled:  true,
+		ExitCode: parallelExitCode(results),
+		Stdout:   output + "\n",
+	}
+}
+
+func hasParallelFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--parallel" {
+			return true
+		}
+	}
+	return false
+}
+
+func parallelErrorOutcome(msg string) parallelRunOutcome {
+	return parallelRunOutcome{
+		Handled:  true,
+		ExitCode: 1,
+		Stderr:   fmt.Sprintf("ERROR: %s\n", msg),
+	}
+}
+
+func parallelExitCode(results []TaskResult) int {
+	exitCode := 0
+	for _, res := range results {
+		if res.ExitCode != 0 {
+			exitCode = res.ExitCode
+		}
+	}
+	return exitCode
+}

--- a/code-dispatcher/parallel_run.go
+++ b/code-dispatcher/parallel_run.go
@@ -73,7 +73,7 @@ func runParallelInvocation(dispatcherName string, args []string) parallelRunOutc
 
 	backend, err := selectBackendFn(backendName)
 	if err != nil {
-		return parallelErrorOutcome(err.Error())
+		return parallelErrorOutcome(fmt.Sprintf("selecting backend %q: %v", backendName, err))
 	}
 	backendName = backend.Name()
 

--- a/code-dispatcher/parallel_run_test.go
+++ b/code-dispatcher/parallel_run_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -85,5 +86,21 @@ do a`)
 	}
 	if !strings.Contains(outcome.Stderr, "unknown key: unknown") {
 		t.Fatalf("stderr = %q, want unknown-key validation error", outcome.Stderr)
+	}
+}
+
+func TestRunParallelInvocationBackendSelectionErrorIncludesBackend(t *testing.T) {
+	defer resetTestHooks()
+
+	selectBackendFn = func(name string) (Backend, error) {
+		return nil, errors.New("backend unavailable")
+	}
+
+	outcome := runParallelInvocation("code-dispatcher", []string{"--parallel", "--backend", "missing"})
+	if !outcome.Handled || outcome.ExitCode != 1 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	if !strings.Contains(outcome.Stderr, `selecting backend "missing": backend unavailable`) {
+		t.Fatalf("stderr = %q, want backend selection context", outcome.Stderr)
 	}
 }

--- a/code-dispatcher/parallel_run_test.go
+++ b/code-dispatcher/parallel_run_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunParallelInvocationIgnoresNonParallelArgs(t *testing.T) {
+	defer resetTestHooks()
+
+	outcome := runParallelInvocation("code-dispatcher", []string{"--backend", "codex", "task"})
+	if outcome.Handled {
+		t.Fatalf("expected non-parallel args to be ignored, got %+v", outcome)
+	}
+}
+
+func TestRunParallelInvocationSummaryOutput(t *testing.T) {
+	defer resetTestHooks()
+
+	stdinReader = strings.NewReader(`---TASK---
+id: a
+---CONTENT---
+do a`)
+	runParallelTaskFn = func(task TaskSpec, timeout int) TaskResult {
+		if task.Backend != "codex" {
+			t.Fatalf("task backend = %q, want codex", task.Backend)
+		}
+		return TaskResult{TaskID: task.ID, ExitCode: 0, Message: "done"}
+	}
+
+	outcome := runParallelInvocation("code-dispatcher", []string{"--parallel", "--backend", "codex"})
+	if !outcome.Handled || outcome.ExitCode != 0 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	if !strings.Contains(outcome.Stdout, "=== Execution Report ===") || !strings.Contains(outcome.Stdout, "a") {
+		t.Fatalf("stdout = %q, want summary report for task a", outcome.Stdout)
+	}
+	if outcome.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", outcome.Stderr)
+	}
+}
+
+func TestRunParallelInvocationFullOutputAndExitCode(t *testing.T) {
+	defer resetTestHooks()
+
+	stdinReader = strings.NewReader(`---TASK---
+id: a
+---CONTENT---
+do a
+---TASK---
+id: b
+---CONTENT---
+do b`)
+	runParallelTaskFn = func(task TaskSpec, timeout int) TaskResult {
+		if task.ID == "b" {
+			return TaskResult{TaskID: task.ID, ExitCode: 7, Error: "failed"}
+		}
+		return TaskResult{TaskID: task.ID, ExitCode: 0, Message: "done"}
+	}
+
+	outcome := runParallelInvocation("code-dispatcher", []string{"--parallel", "--backend", "codex", "--full-output"})
+	if !outcome.Handled || outcome.ExitCode != 7 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	if !strings.Contains(outcome.Stdout, "=== Parallel Execution Summary ===") {
+		t.Fatalf("stdout = %q, want full output summary", outcome.Stdout)
+	}
+	if !strings.Contains(outcome.Stdout, "Status: FAILED (exit code 7)") {
+		t.Fatalf("stdout = %q, want failed task status", outcome.Stdout)
+	}
+}
+
+func TestRunParallelInvocationValidationError(t *testing.T) {
+	defer resetTestHooks()
+
+	stdinReader = strings.NewReader(`---TASK---
+id: a
+unknown: nope
+---CONTENT---
+do a`)
+
+	outcome := runParallelInvocation("code-dispatcher", []string{"--parallel", "--backend", "codex"})
+	if !outcome.Handled || outcome.ExitCode != 1 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	if !strings.Contains(outcome.Stderr, "unknown key: unknown") {
+		t.Fatalf("stderr = %q, want unknown-key validation error", outcome.Stderr)
+	}
+}

--- a/code-dispatcher/report_projection.go
+++ b/code-dispatcher/report_projection.go
@@ -23,16 +23,22 @@ type ProjectedTaskResult struct {
 	Report TaskReportProjection
 }
 
+type projectedTaskStatus struct {
+	success     bool
+	belowTarget bool
+	target      float64
+}
+
 func projectTaskResults(results []TaskResult) []ProjectedTaskResult {
 	projected := make([]ProjectedTaskResult, len(results))
 	for i, result := range results {
-		projected[i] = projectTaskResult(result, defaultCoverageTarget)
+		projected[i] = projectTaskResult(result)
 	}
 	return projected
 }
 
-func projectTaskResult(result TaskResult, coverageTarget float64) ProjectedTaskResult {
-	projection := TaskReportProjection{CoverageTarget: coverageTarget}
+func projectTaskResult(result TaskResult) ProjectedTaskResult {
+	projection := TaskReportProjection{CoverageTarget: defaultCoverageTarget}
 	if report, found := extractStructuredReport(result.Message, reportProjectionSummaryMaxLen); found {
 		projection.Found = true
 		projection.Coverage = report.Coverage
@@ -57,6 +63,20 @@ func generateProjectedFinalOutput(results []ProjectedTaskResult) string {
 	return generateProjectedFinalOutputWithMode(results, true)
 }
 
+func statusForProjectedTask(projected ProjectedTaskResult, fallbackCoverageTarget float64) projectedTaskStatus {
+	res := projected.Result
+	report := projected.Report
+	status := projectedTaskStatus{
+		success: res.ExitCode == 0 && res.Error == "",
+		target:  report.CoverageTarget,
+	}
+	if status.target <= 0 {
+		status.target = fallbackCoverageTarget
+	}
+	status.belowTarget = status.success && report.Coverage != "" && status.target > 0 && report.CoverageNum < status.target
+	return status
+}
+
 // generateProjectedFinalOutputWithMode generates output based on mode.
 // summaryOnly=true: structured report - every token has value.
 // summaryOnly=false: full output with complete messages.
@@ -70,15 +90,10 @@ func generateProjectedFinalOutputWithMode(results []ProjectedTaskResult, summary
 	failed := 0
 	belowTarget := 0
 	for _, projected := range results {
-		res := projected.Result
-		report := projected.Report
-		if res.ExitCode == 0 && res.Error == "" {
+		status := statusForProjectedTask(projected, reportCoverageTarget)
+		if status.success {
 			success++
-			target := report.CoverageTarget
-			if target <= 0 {
-				target = reportCoverageTarget
-			}
-			if report.Coverage != "" && target > 0 && report.CoverageNum < target {
+			if status.belowTarget {
 				belowTarget++
 			}
 		} else {
@@ -107,15 +122,9 @@ func generateProjectedFinalOutputWithMode(results []ProjectedTaskResult, summary
 				return sanitizeOutput(strings.Join(report.FilesChanged, ", "))
 			}
 
-			target := report.CoverageTarget
-			if target <= 0 {
-				target = reportCoverageTarget
-			}
+			status := statusForProjectedTask(projected, reportCoverageTarget)
 
-			isSuccess := res.ExitCode == 0 && res.Error == ""
-			isBelowTarget := isSuccess && coverage != "" && target > 0 && report.CoverageNum < target
-
-			if isSuccess && !isBelowTarget {
+			if status.success && !status.belowTarget {
 				sb.WriteString(fmt.Sprintf("\n### %s %s", taskID, successSymbol))
 				if coverage != "" {
 					sb.WriteString(fmt.Sprintf(" %s", coverage))
@@ -135,8 +144,8 @@ func generateProjectedFinalOutputWithMode(results []ProjectedTaskResult, summary
 					sb.WriteString(fmt.Sprintf("Log: %s\n", logPath))
 				}
 
-			} else if isSuccess && isBelowTarget {
-				sb.WriteString(fmt.Sprintf("\n### %s %s %s (below %.0f%%)\n", taskID, warningSymbol, coverage, target))
+			} else if status.success && status.belowTarget {
+				sb.WriteString(fmt.Sprintf("\n### %s %s %s (below %.0f%%)\n", taskID, warningSymbol, coverage, status.target))
 
 				if keyOutput != "" {
 					sb.WriteString(fmt.Sprintf("Did: %s\n", keyOutput))
@@ -179,7 +188,6 @@ func generateProjectedFinalOutputWithMode(results []ProjectedTaskResult, summary
 			var needCoverage []string
 			for _, projected := range results {
 				res := projected.Result
-				report := projected.Report
 				if res.ExitCode != 0 || res.Error != "" {
 					taskID := sanitizeOutput(res.TaskID)
 					reason := sanitizeOutput(res.Error)
@@ -191,11 +199,7 @@ func generateProjectedFinalOutputWithMode(results []ProjectedTaskResult, summary
 					continue
 				}
 
-				target := report.CoverageTarget
-				if target <= 0 {
-					target = reportCoverageTarget
-				}
-				if report.Coverage != "" && target > 0 && report.CoverageNum < target {
+				if statusForProjectedTask(projected, reportCoverageTarget).belowTarget {
 					needCoverage = append(needCoverage, sanitizeOutput(res.TaskID))
 				}
 			}

--- a/code-dispatcher/report_projection_test.go
+++ b/code-dispatcher/report_projection_test.go
@@ -31,7 +31,7 @@ func TestProjectTaskResultUsesExplicitReportOnly(t *testing.T) {
 		Message: "noise fallback.go 12%\n" + structuredReportMessageForTest("92%", "structured.go", "7 passed, 0 failed", "Structured report used"),
 	}
 
-	projected := projectTaskResult(result, defaultCoverageTarget)
+	projected := projectTaskResult(result)
 
 	if !projected.Report.Found {
 		t.Fatalf("expected report projection to be found")
@@ -59,7 +59,7 @@ func TestProjectTaskResultDoesNotGuessWithoutReport(t *testing.T) {
 		Message: "Summary: Should not be extracted\nCoverage: 88%\nFiles: guessed.go\nTests: 4 passed, 0 failed",
 	}
 
-	projected := projectTaskResult(result, defaultCoverageTarget)
+	projected := projectTaskResult(result)
 
 	if projected.Report.Found {
 		t.Fatalf("unexpected report projection: %#v", projected.Report)
@@ -90,8 +90,8 @@ func TestGenerateFinalOutputDoesNotInventReportFieldsWithoutStructuredReport(t *
 
 func TestGenerateProjectedFinalOutputWithMode(t *testing.T) {
 	results := []ProjectedTaskResult{
-		projectTaskResult(TaskResult{TaskID: "ok", ExitCode: 0, Message: structuredReportMessageForTest("92%", "a.go", "3 passed, 0 failed", "done")}, defaultCoverageTarget),
-		projectTaskResult(TaskResult{TaskID: "warn", ExitCode: 0, Message: structuredReportMessageForTest("80%", "b.go", "2 passed, 0 failed", "needs coverage")}, defaultCoverageTarget),
+		projectTaskResult(TaskResult{TaskID: "ok", ExitCode: 0, Message: structuredReportMessageForTest("92%", "a.go", "3 passed, 0 failed", "done")}),
+		projectTaskResult(TaskResult{TaskID: "warn", ExitCode: 0, Message: structuredReportMessageForTest("80%", "b.go", "2 passed, 0 failed", "needs coverage")}),
 		{Result: TaskResult{TaskID: "bad", ExitCode: 2, Error: "boom", Message: "panic: bad"}},
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Extract parallel execution handling and report generation into dedicated modules while simplifying task result data and updating tests to target the new projection and orchestration APIs.

Enhancements:
- Introduce a projection layer that derives structured coverage and summary data from task messages and centralizes final report generation for both summary and full-output modes.
- Factor parallel CLI handling into a reusable helper that parses flags, runs concurrent tasks, and returns structured outcomes, then wire main() to use it.
- Simplify TaskResult by removing embedded structured-report fields in favor of deriving them from messages, and adjust integration and executor tests to reflect the new flow.

Tests:
- Add focused tests for report projection and parallel run orchestration, and update existing integration and concurrent executor tests to validate the new reporting and CLI behavior.

---

Linked issue: Closes #46
