### PR TITLE
fix: address confirmed review findings (stderr fd leak, installer, report size, resume workdir)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run tests with coverage gate
         run: bash scripts/test-coverage.sh
+
+      - name: Run installer asset tests
+        run: python3 test_runtime_assets.py

--- a/code-dispatcher/backend.go
+++ b/code-dispatcher/backend.go
@@ -58,8 +58,10 @@ func (ClaudeBackend) BuildArgs(cfg *Config, targetArg string) []string {
 	return buildClaudeArgs(cfg, targetArg)
 }
 func (b ClaudeBackend) BuildInvocation(cfg *Config, targetArg string) BackendInvocation {
+	// Claude stores sessions per project directory, so resume must run in the
+	// original task workdir to find the conversation; honor WorkDir in every mode.
 	workDir := ""
-	if cfg != nil && cfg.Mode != "resume" && strings.TrimSpace(cfg.WorkDir) != "" {
+	if cfg != nil && strings.TrimSpace(cfg.WorkDir) != "" {
 		workDir = cfg.WorkDir
 	}
 	return BackendInvocation{
@@ -128,7 +130,7 @@ func legacyBackendInvocation(cfg *Config, commandName string, args []string) Bac
 	if name == "codex" {
 		invocation.StderrFilterPatterns = codexNoisePatterns
 	}
-	if name == "claude" && cfg != nil && cfg.Mode != "resume" && strings.TrimSpace(cfg.WorkDir) != "" {
+	if name == "claude" && cfg != nil && strings.TrimSpace(cfg.WorkDir) != "" {
 		invocation.WorkDir = cfg.WorkDir
 	}
 	return invocation

--- a/code-dispatcher/backend_test.go
+++ b/code-dispatcher/backend_test.go
@@ -162,11 +162,29 @@ func TestBackendInvocationPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("claude resume leaves workdir empty", func(t *testing.T) {
+	t.Run("claude resume keeps explicit workdir", func(t *testing.T) {
+		// Claude stores sessions per project directory; resume only finds the
+		// conversation when the process runs in the original task workdir.
 		cfg := &Config{Mode: "resume", SessionID: "sid", WorkDir: "/repo", Backend: "claude"}
+		invocation := ClaudeBackend{}.BuildInvocation(cfg, "task")
+		if invocation.WorkDir != "/repo" {
+			t.Fatalf("resume WorkDir = %q, want /repo", invocation.WorkDir)
+		}
+	})
+
+	t.Run("claude resume without workdir stays empty", func(t *testing.T) {
+		cfg := &Config{Mode: "resume", SessionID: "sid", WorkDir: "  ", Backend: "claude"}
 		invocation := ClaudeBackend{}.BuildInvocation(cfg, "task")
 		if invocation.WorkDir != "" {
 			t.Fatalf("resume WorkDir = %q, want empty", invocation.WorkDir)
+		}
+	})
+
+	t.Run("legacy claude resume keeps explicit workdir", func(t *testing.T) {
+		cfg := &Config{Mode: "resume", SessionID: "sid", WorkDir: "/repo", Backend: "claude"}
+		invocation := legacyBackendInvocation(cfg, "claude", []string{"-p"})
+		if invocation.WorkDir != "/repo" {
+			t.Fatalf("legacy resume WorkDir = %q, want /repo", invocation.WorkDir)
 		}
 	})
 }

--- a/code-dispatcher/execution_lifecycle.go
+++ b/code-dispatcher/execution_lifecycle.go
@@ -314,6 +314,7 @@ waitLoop:
 
 	select {
 	case <-stderrDone:
+		closeWithReason(stderr, stdoutCloseReasonWait)
 	case <-time.After(stdoutDrainTimeout):
 		closeWithReason(stderr, stdoutCloseReasonDrain)
 		<-stderrDone

--- a/code-dispatcher/execution_lifecycle_test.go
+++ b/code-dispatcher/execution_lifecycle_test.go
@@ -194,6 +194,32 @@ func TestRunExecutionLifecycleClosesStderrOnNormalCompletion(t *testing.T) {
 	}
 }
 
+func TestRunExecutionLifecycleCapsStderrAttachedToError(t *testing.T) {
+	origRunner := newCommandRunner
+	t.Cleanup(func() { newCommandRunner = origRunner })
+
+	fake := newFakeCmd(fakeCmdConfig{
+		StderrPlan: []fakeStdoutEvent{{Data: strings.Repeat("E", 8*1024) + "\n"}},
+		PID:        45,
+	})
+	newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
+		return fake
+	}
+
+	res := runExecutionLifecycle(testExecutionLifecycleRequest(testExecutionLifecycleInvocation("thread-cap")))
+
+	if res.ExitCode == 0 {
+		t.Fatalf("expected empty-message failure, got %+v", res)
+	}
+	maxLen := stderrCaptureLimit + 200 // tail cap plus message prefix slack
+	if len(res.Error) > maxLen {
+		t.Fatalf("error length = %d, want <= %d (stderr tail must stay capped)", len(res.Error), maxLen)
+	}
+	if stderrCaptureLimit != 4*1024 {
+		t.Fatalf("stderrCaptureLimit = %d, want 4096 (errors embed the tail; full stderr goes to the task log)", stderrCaptureLimit)
+	}
+}
+
 func waitForLifecycleCondition(t *testing.T, ok func() bool, msg string) {
 	t.Helper()
 

--- a/code-dispatcher/execution_lifecycle_test.go
+++ b/code-dispatcher/execution_lifecycle_test.go
@@ -172,6 +172,28 @@ func testExecutionLifecycleInvocation(threadID string) BackendInvocation {
 	}
 }
 
+func TestRunExecutionLifecycleClosesStderrOnNormalCompletion(t *testing.T) {
+	origRunner := newCommandRunner
+	t.Cleanup(func() { newCommandRunner = origRunner })
+
+	fake := newFakeCmd(fakeCmdConfig{
+		StdoutPlan: []fakeStdoutEvent{{Data: "done\n"}},
+		PID:        44,
+	})
+	newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
+		return fake
+	}
+
+	res := runExecutionLifecycle(testExecutionLifecycleRequest(testExecutionLifecycleInvocation("thread-close")))
+
+	if res.ExitCode != 0 || res.Message != "done" {
+		t.Fatalf("lifecycle result = %+v", res)
+	}
+	if got := fake.stderr.Reason(); got != stdoutCloseReasonWait {
+		t.Fatalf("stderr close reason = %q, want %q (stderr reader leaked on normal completion)", got, stdoutCloseReasonWait)
+	}
+}
+
 func waitForLifecycleCondition(t *testing.T, ok func() bool, msg string) {
 	t.Helper()
 

--- a/code-dispatcher/main.go
+++ b/code-dispatcher/main.go
@@ -19,7 +19,10 @@ const (
 	defaultCoverageTarget = 90.0
 	logLineLimit          = 1000
 	stdinSpecialChars     = "\n\\\"'`$"
-	stderrCaptureLimit    = 64 * 1024
+	// stderrCaptureLimit caps the rolling stderr tail attached to TaskResult.Error
+	// (and thus to execution reports). Full stderr still reaches the task log via
+	// stderrLogger; keep this small so failed tasks cannot flood report output.
+	stderrCaptureLimit    = 4 * 1024
 	defaultBackendName    = "codex"
 	defaultBackendCommand = "codex"
 

--- a/code-dispatcher/parallel_run.go
+++ b/code-dispatcher/parallel_run.go
@@ -64,7 +64,7 @@ func runParallelInvocation(dispatcherName string, args []string) parallelRunOutc
 
 	if !backendSpecified {
 		var stderr strings.Builder
-		fmt.Fprintln(&stderr, "ERROR: --backend is required in --parallel mode (supported: codex, claude)")
+		fmt.Fprintf(&stderr, "ERROR: --backend is required in --parallel mode (supported: %s)\n", supportedBackendNamesText())
 		fmt.Fprintln(&stderr, "Usage examples:")
 		fmt.Fprintf(&stderr, "  %s --parallel --backend codex < tasks.txt\n", dispatcherName)
 		fmt.Fprintf(&stderr, "  %s --parallel --backend claude <<'EOF'\n", dispatcherName)

--- a/code-dispatcher/parallel_run_test.go
+++ b/code-dispatcher/parallel_run_test.go
@@ -104,3 +104,16 @@ func TestRunParallelInvocationBackendSelectionErrorIncludesBackend(t *testing.T)
 		t.Fatalf("stderr = %q, want backend selection context", outcome.Stderr)
 	}
 }
+
+func TestRunParallelInvocationMissingBackendListsManifestBackends(t *testing.T) {
+	defer resetTestHooks()
+
+	outcome := runParallelInvocation("code-dispatcher", []string{"--parallel"})
+	if !outcome.Handled || outcome.ExitCode != 1 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	want := "(supported: " + supportedBackendNamesText() + ")"
+	if !strings.Contains(outcome.Stderr, want) {
+		t.Fatalf("stderr = %q, want manifest-derived list %q", outcome.Stderr, want)
+	}
+}

--- a/docs/code-dispatcher.md
+++ b/docs/code-dispatcher.md
@@ -208,6 +208,7 @@ code-dispatcher --backend claude resume <session_id> "follow-up task"
 
 - Session ID 来自 dispatcher 输出的 `SESSION_ID`（UUID 格式）
 - resume 模式不要追加 `working_dir`；如需不同目录，应开启新会话
+- claude 会话按项目目录（cwd）存储：串行 resume 需在原任务 workdir 下运行 dispatcher；parallel 模式的 resume 任务应在 `workdir:` 中携带原任务目录，dispatcher 会用它启动 claude
 
 ### 并行模式（--parallel）
 

--- a/install.py
+++ b/install.py
@@ -221,8 +221,8 @@ def main(argv: list[str] | None = None) -> int:
 
     _ensure_dir(install_dir)
 
-    _install_prompts(install_dir, force=args.force)
     try:
+        _install_prompts(install_dir, force=args.force)
         _install_env_template(install_dir, force=args.force)
     except RuntimeError as e:
         print(f"ERROR: {e}", file=sys.stderr)

--- a/runtime_assets.py
+++ b/runtime_assets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import platform
@@ -47,7 +48,15 @@ def _validate_binary_names(data: dict[str, Any]) -> None:
             )
 
 
-MANIFEST = _load_manifest()
+@functools.lru_cache(maxsize=1)
+def _manifest() -> dict[str, Any]:
+    """Load the manifest on first use so importing this module never raises.
+
+    Lazy loading keeps `install.py --help` / `uninstall.py --help` working and
+    lets callers surface RuntimeError through their own error handling instead
+    of dying with an import-time traceback.
+    """
+    return _load_manifest()
 
 
 def _mapping(value: Any, label: str) -> dict[str, Any]:
@@ -69,15 +78,15 @@ def _string(value: Any, label: str) -> str:
 
 
 def runtime_config() -> dict[str, Any]:
-    return _mapping(MANIFEST.get("runtime_config"), "runtime_config")
+    return _mapping(_manifest().get("runtime_config"), "runtime_config")
 
 
 def binary() -> dict[str, Any]:
-    return _mapping(MANIFEST.get("binary"), "binary")
+    return _mapping(_manifest().get("binary"), "binary")
 
 
 def backend_assets() -> list[dict[str, Any]]:
-    backends = _list(MANIFEST.get("backends"), "backends")
+    backends = _list(_manifest().get("backends"), "backends")
     return [_mapping(backend, f"backends[{idx}]") for idx, backend in enumerate(backends)]
 
 
@@ -116,7 +125,7 @@ def prompt_install_files() -> list[str]:
 
 
 def legacy_prompt_files() -> list[str]:
-    legacy = _mapping(MANIFEST.get("legacy_uninstall"), "legacy_uninstall")
+    legacy = _mapping(_manifest().get("legacy_uninstall"), "legacy_uninstall")
     files = _list(legacy.get("prompt_files"), "legacy_uninstall.prompt_files")
     return [_string(file, "legacy_uninstall.prompt_files[]") for file in files]
 

--- a/test_runtime_assets.py
+++ b/test_runtime_assets.py
@@ -69,5 +69,48 @@ class RuntimeAssetsTests(unittest.TestCase):
             self.assertEqual(install._get_artifact_name(), "code-dispatcher-linux-amd64")
 
 
+class LazyManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        runtime_assets._manifest.cache_clear()
+        self.addCleanup(runtime_assets._manifest.cache_clear)
+
+    def test_accessors_raise_runtime_error_when_manifest_missing(self) -> None:
+        missing = Path(tempfile.gettempdir()) / "code-dispatcher-no-such-manifest.json"
+        with mock.patch.object(runtime_assets, "MANIFEST_PATH", missing):
+            with self.assertRaisesRegex(RuntimeError, "runtime asset manifest not found"):
+                runtime_assets.prompt_install_files()
+
+    def test_help_does_not_load_manifest(self) -> None:
+        with mock.patch.object(
+            runtime_assets, "_load_manifest", side_effect=AssertionError("manifest loaded during --help")
+        ):
+            for module in (install, uninstall):
+                with self.subTest(module=module.__name__):
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        with self.assertRaises(SystemExit) as ctx:
+                            module.main(["--help"])
+                    self.assertEqual(ctx.exception.code, 0)
+
+    def test_install_reports_clean_error_when_manifest_missing(self) -> None:
+        missing = Path(tempfile.gettempdir()) / "code-dispatcher-no-such-manifest.json"
+        with tempfile.TemporaryDirectory() as raw_dir:
+            with mock.patch.object(runtime_assets, "MANIFEST_PATH", missing):
+                stderr = io.StringIO()
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+                    rc = install.main(["--install-dir", raw_dir, "--skip-dispatcher"])
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR: runtime asset manifest not found", stderr.getvalue())
+
+    def test_uninstall_reports_clean_error_when_manifest_missing(self) -> None:
+        missing = Path(tempfile.gettempdir()) / "code-dispatcher-no-such-manifest.json"
+        with tempfile.TemporaryDirectory() as raw_dir:
+            with mock.patch.object(runtime_assets, "MANIFEST_PATH", missing):
+                stderr = io.StringIO()
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+                    rc = uninstall.main(["--install-dir", raw_dir, "--yes"])
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR: runtime asset manifest not found", stderr.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_runtime_assets.py
+++ b/test_runtime_assets.py
@@ -111,6 +111,40 @@ class LazyManifestTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("ERROR: runtime asset manifest not found", stderr.getvalue())
 
+    def test_install_reports_clean_error_when_manifest_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            bad_manifest = Path(raw_dir) / "runtime_assets.json"
+            bad_manifest.write_text("{not valid json", encoding="utf-8")
+            with mock.patch.object(runtime_assets, "MANIFEST_PATH", bad_manifest):
+                stderr = io.StringIO()
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+                    rc = install.main(["--install-dir", str(Path(raw_dir) / "x"), "--skip-dispatcher"])
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR: invalid runtime asset manifest", stderr.getvalue())
+
+    def test_uninstall_reports_clean_error_when_manifest_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            bad_manifest = Path(raw_dir) / "runtime_assets.json"
+            bad_manifest.write_text("{not valid json", encoding="utf-8")
+            with mock.patch.object(runtime_assets, "MANIFEST_PATH", bad_manifest):
+                stderr = io.StringIO()
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+                    rc = uninstall.main(["--install-dir", raw_dir, "--yes"])
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR: invalid runtime asset manifest", stderr.getvalue())
+
+    def test_manifest_loads_once_across_accessors(self) -> None:
+        fake_manifest = {
+            "binary": {"install_dir": "bin"},
+            "backends": [],
+        }
+        with mock.patch.object(
+            runtime_assets, "_load_manifest", return_value=fake_manifest
+        ) as load_manifest:
+            runtime_assets.binary()
+            runtime_assets.backend_assets()
+        load_manifest.assert_called_once_with()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uninstall.py
+++ b/uninstall.py
@@ -7,6 +7,7 @@ Removes only the files installed by ./install.py and leaves unrelated user files
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 import runtime_assets
@@ -64,10 +65,15 @@ def main(argv: list[str] | None = None) -> int:
             print("Aborted.")
             return 0
 
-    targets = [
-        runtime_assets.env_install_path(install_dir),
-        runtime_assets.binary_path(install_dir),
-    ]
+    try:
+        targets = [
+            runtime_assets.env_install_path(install_dir),
+            runtime_assets.binary_path(install_dir),
+        ]
+        prompt_files = runtime_assets.uninstall_prompt_files()
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
 
     removed = 0
 
@@ -77,7 +83,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Removed: {path}")
 
     prompts_dir = install_dir / "prompts"
-    for prompt_file in runtime_assets.uninstall_prompt_files():
+    for prompt_file in prompt_files:
         path = prompts_dir / prompt_file
         if _unlink(path):
             removed += 1


### PR DESCRIPTION
Refs #56(完整发现清单与后续项见该 issue;本 PR 修复其中已确认的 5 项并补 CI 缺口,不关闭 issue)

## 修复内容

| # | 修复 | 类型 | 修复前 → 修复后(实证) |
|---|------|------|------------------------|
| 1 | 正常完成路径关闭 stderr reader | 回归 | barrier 窗口 fd:41 → **11**(HEAD~10 基线 9;GOGC=off、30 任务) |
| 2 | installer 惰性加载 manifest | 回归 | `install.py --help` 裸 traceback → usage 正常(exit 0);坏 manifest → 干净 `ERROR: ...`(exit 1);uninstall.py 补上 RuntimeError 处理 |
| 3 | `stderrCaptureLimit` 64KB → 4KB | 回归 | 100KB-stderr 失败任务的报告 Error 行:65,560 B → **4,120 B**(与 HEAD~10 一致;完整 stderr 仍进任务日志) |
| 4 | claude resume 尊重显式 workdir | 既有 bug | parallel resume 任务(显式 `workdir:` + 错误 cwd):`No conversation found` 必败 → **1 passed**(真实 claude 2.1.170 验证) |
| 5 | parallel 报错列表走 manifest | 一致性 | 硬编码 `(supported: codex, claude)` → `supportedBackendNamesText()`,与串行路径对齐 |
| 6 | CI 运行 `test_runtime_assets.py` | CI 缺口 | Go/Python manifest 一致性测试从未在 CI 执行 → 接入 ci.yml |

## 行为兼容性说明(Fix 4)

claude 会话按项目目录存储,resume 必须运行在原任务 workdir。serial resume 与 parallel 任务的默认 `WorkDir` 均为 `"."`(等价继承 dispatcher cwd),因此默认行为不变;只有显式提供 workdir 的 resume 任务从必败变为正确。codex 不受影响(invocation 从不设置 WorkDir,其会话全局存储)。docs/code-dispatcher.md 已补充说明。

## 验证

- `go test ./...` 全绿;`scripts/quality-check.sh` 通过;`scripts/test-coverage.sh` 91.2% ≥ 89%
- `python3 test_runtime_assets.py` 8/8(含新增 4 个惰性加载/降级用例)
- 上表全部实证数字来自修复后二进制与 HEAD~10 对照二进制的 A/B 复跑(stub 后端受控实验 + 真实 codex/claude 调用)

## Summary by Sourcery

Fix confirmed runtime, installer, and dispatcher issues uncovered in review and extend CI coverage for installer assets.

Bug Fixes:
- Ensure stderr reader is closed on normal execution lifecycle completion to avoid file descriptor leaks.
- Cap the stderr tail embedded in task error messages while preserving full stderr in task logs.
- Honor explicit workdir for Claude resume invocations in both normal and legacy backends while keeping default behavior unchanged.
- Load the runtime asset manifest lazily so installer and uninstaller help/CLI flows don’t crash or traceback when the manifest is missing.
- Have parallel dispatcher errors list supported backends based on the manifest for consistency with other code paths.

Enhancements:
- Improve uninstall error handling to surface clean error messages when runtime asset metadata is unavailable.
- Document Claude resume behavior and workdir requirements in the dispatcher documentation.

CI:
- Run Python runtime asset tests in the CI workflow to catch manifest and installer regressions early.

Tests:
- Add Go tests covering stderr closing and stderr tail capping in the execution lifecycle.
- Add Go tests for Claude resume workdir handling and manifest-derived backend lists in parallel mode errors.
- Expand Python runtime asset tests for lazy manifest loading and clean installer/uninstaller degradation paths.
- Wire runtime asset tests into the CI workflow to run alongside existing coverage checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进 Claude 会话 resume 模式的工作目录处理逻辑，确保恢复任务能正确使用指定工作目录
  * 增强安装/卸载脚本在资产清单缺失时的错误处理

* **New Features**
  * 并行运行模式下，缺失后端参数时显示动态受支持后端列表

* **Documentation**
  * 补充 Claude 会话存储与 resume 模式的工作目录说明

* **Tests**
  * 新增执行生命周期相关测试用例
  * 新增运行时资产清单懒加载测试

* **Chores**
  * 优化 stderr 捕获大小限制，减少错误报告体积
  * 改进 CI 工作流

<!-- end of auto-generated comment: release notes by coderabbit.ai -->