### PR TITLE
refactor: close out issue #56 cleanly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,5 @@ jobs:
           go-version-file: code-dispatcher/go.mod
           cache: false
 
-      - name: Run quality checks
-        run: bash scripts/quality-check.sh
-
-      - name: Run tests with coverage gate
-        run: bash scripts/test-coverage.sh
-
-      - name: Run installer asset tests
-        run: python3 test_runtime_assets.py
+      - name: Run verification gate
+        run: bash scripts/verify.sh

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -28,11 +28,8 @@ jobs:
           go-version-file: code-dispatcher/go.mod
           cache: false
 
-      - name: Run quality checks
-        run: bash scripts/quality-check.sh
-
-      - name: Run tests with coverage gate
-        run: bash scripts/test-coverage.sh
+      - name: Run verification gate
+        run: bash scripts/verify.sh
 
       - name: Build cross-platform binaries
         run: bash scripts/build-dist.sh

--- a/README.en.md
+++ b/README.en.md
@@ -100,31 +100,11 @@ The script installs the following:
 
 - `~/.code-dispatcher/.env`: single runtime config source
 - `~/.code-dispatcher/prompts/*-prompt.md`: default prompt templates for each backend (editable; leave empty to disable injection)
-- `~/.code-dispatcher/bin/code-dispatcher` (`.exe` on Windows, etc.)
+- binary: installed to the directory and filename declared by `runtime_assets.json`; `install.py` prints the actual path
 
 **Important**: Different platforms have different code agent shell environments, so they cannot all be assumed to follow the same execution pattern.
 
-`install.py` outputs persistence commands for common shells (Windows: PowerShell, CMD, Git Bash; Non-Windows: Bash, Zsh, Fish). The examples below use the default install path:
-
-```bash
-Windows PowerShell:
-[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$HOME\.code-dispatcher\bin", "User")
-
-Windows CMD:
-setx PATH "%PATH%;%USERPROFILE%\.code-dispatcher\bin"
-
-Git Bash (e.g. Claude Code on Windows):
-echo 'export PATH="$HOME/.code-dispatcher/bin:$PATH"' >> ~/.bashrc
-
-Bash (e.g. WSL/Linux):
-echo 'export PATH="$PATH:$HOME/.code-dispatcher/bin"' >> ~/.bashrc
-
-Zsh (e.g. macOS default):
-echo 'export PATH="$PATH:$HOME/.code-dispatcher/bin"' >> ~/.zshrc
-
-Fish:
-echo 'set -gx PATH "$HOME/.code-dispatcher/bin" $PATH' >> ~/.config/fish/config.fish
-```
+`install.py` derives the binary directory from the manifest and prints the appropriate persistent PATH commands for common shells. Use that output directly instead of maintaining a duplicated fixed `bin` path in documentation.
 
 ### Step 2: Install Code Dispatcher Skill
 
@@ -175,23 +155,13 @@ For full field definitions, see: [docs/runtime-config.en.md](docs/runtime-config
 
 ### Running Tests
 
+Run the single verification entry point before submitting changes:
+
 ```bash
-cd code-dispatcher
-go test ./...
-
-# Verify local build
-cd ..
-bash scripts/build-dist.sh
-
-# Verify install script syntax and template references
-python3 -m py_compile install.py
-
-# Non-polluting install regression test (using temp directory)
-tmpdir="$(mktemp -d)"
-python3 install.py --install-dir "$tmpdir/.code-dispatcher" --skip-dispatcher --force
-python3 install.py --install-dir "$tmpdir/.code-dispatcher" --force
-rm -rf "$tmpdir"
+bash scripts/verify.sh
 ```
+
+It runs formatting and static analysis, the race-enabled coverage gate, and the installer/runtime asset contract tests. Pull-request CI and release publishing use the same entry point.
 
 ## Community / Contributing
 

--- a/README.md
+++ b/README.md
@@ -100,31 +100,11 @@ python3 install.py --skip-dispatcher
 
 - `~/.code-dispatcher/.env`：运行时唯一配置源
 - `~/.code-dispatcher/prompts/*-prompt.md`：每个后端的默认 prompt 模板（可编辑，置空则禁用注入）
-- `~/.code-dispatcher/bin/code-dispatcher`（Windows 上是 `.exe`，以此类推）
+- binary：安装到 `runtime_assets.json` 声明的目录与文件名；实际路径由 `install.py` 输出
 
 特别需要注意的是：不同平台下 code agent 的 shell 环境并不完全一致，不能默认都按同一套假设执行。
 
-`install.py` 会直接输出常见 shell 的持久化设置命令（Windows：PowerShell、CMD、Git Bash；非 Windows：Bash、Zsh、Fish）。下面是默认安装路径示例：
-
-```bash
-Windows PowerShell:
-[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$HOME\.code-dispatcher\bin", "User")
-
-Windows CMD:
-setx PATH "%PATH%;%USERPROFILE%\.code-dispatcher\bin"
-
-Git Bash (e.g. Claude Code on Windows):
-echo 'export PATH="$HOME/.code-dispatcher/bin:$PATH"' >> ~/.bashrc
-
-Bash (e.g. WSL/Linux):
-echo 'export PATH="$PATH:$HOME/.code-dispatcher/bin"' >> ~/.bashrc
-
-Zsh (e.g. macOS 默认):
-echo 'export PATH="$PATH:$HOME/.code-dispatcher/bin"' >> ~/.zshrc
-
-Fish:
-echo 'set -gx PATH "$HOME/.code-dispatcher/bin" $PATH' >> ~/.config/fish/config.fish
-```
+`install.py` 会根据 manifest 中的实际 binary 目录输出当前平台常用 shell 的 PATH 持久化命令。安装完成后直接使用脚本输出，不在文档中重复维护固定的 `bin` 路径。
 
 ### Step 2: 安装 Code Dispatcher Skill 
 
@@ -175,23 +155,13 @@ use dispatcher with codex to fix the bug we just discussed
 
 ### 运行验证
 
+提交前执行统一验证入口：
+
 ```bash
-cd code-dispatcher
-go test ./...
-
-# 验证本地构建
-cd ..
-bash scripts/build-dist.sh
-
-# 验证安装脚本语法与模板引用
-python3 -m py_compile install.py
-
-# 不污染真实环境的安装回归（使用临时目录）
-tmpdir="$(mktemp -d)"
-python3 install.py --install-dir "$tmpdir/.code-dispatcher" --skip-dispatcher --force
-python3 install.py --install-dir "$tmpdir/.code-dispatcher" --force
-rm -rf "$tmpdir"
+bash scripts/verify.sh
 ```
+
+该入口依次运行格式与静态检查、race + coverage gate，以及 installer/runtime asset contract tests。PR CI 与发布流程使用同一个入口。
 
 ## 社区与贡献
 

--- a/code-dispatcher/backend.go
+++ b/code-dispatcher/backend.go
@@ -10,8 +10,6 @@ import (
 // backend invocation.
 type Backend interface {
 	Name() string
-	BuildArgs(cfg *Config, targetArg string) []string
-	Command() string
 	BuildInvocation(cfg *Config, targetArg string) BackendInvocation
 }
 
@@ -99,35 +97,6 @@ func runtimeInjectedEnvForInvocation() map[string]string {
 		return nil
 	}
 	return env
-}
-
-// legacyBackendInvocation builds the invocation for the global-hook execution
-// path, where tests may inject commandName and pre-built args. Backend policy
-// (env injection, unset keys, workdir, stream parsing) is delegated to the
-// registry backend so it lives in exactly one place; command and args are then
-// overridden with the caller-provided values.
-func legacyBackendInvocation(cfg *Config, commandName string, args []string) BackendInvocation {
-	if cfg == nil {
-		// selectBackend resolves an empty name to the default backend, whose
-		// BuildInvocation must never see a nil config (buildCodexArgs panics).
-		cfg = &Config{}
-	}
-	name := normalizeBackendName(cfg.Backend)
-	backend, err := selectBackendFn(name)
-	if err != nil {
-		// Unknown backend: keep a generic invocation without backend policy.
-		return BackendInvocation{
-			BackendName: name,
-			Command:     commandName,
-			Args:        args,
-			Env:         runtimeInjectedEnvForInvocation(),
-			ParseStream: parseJSONStreamInternal,
-		}
-	}
-	invocation := backend.BuildInvocation(cfg, "")
-	invocation.Command = commandName
-	invocation.Args = args
-	return invocation
 }
 
 func buildCodexArgs(cfg *Config, targetArg string) []string {

--- a/code-dispatcher/backend_test.go
+++ b/code-dispatcher/backend_test.go
@@ -67,7 +67,7 @@ func TestVariousBackendsBuildArgs(t *testing.T) {
 
 }
 
-func TestClaudeBuildArgs_BackendMetadata(t *testing.T) {
+func TestBackendMetadata(t *testing.T) {
 	tests := []struct {
 		backend Backend
 		name    string
@@ -81,8 +81,9 @@ func TestClaudeBuildArgs_BackendMetadata(t *testing.T) {
 		if got := tt.backend.Name(); got != tt.name {
 			t.Fatalf("Name() = %s, want %s", got, tt.name)
 		}
-		if got := tt.backend.Command(); got != tt.command {
-			t.Fatalf("Command() = %s, want %s", got, tt.command)
+		invocation := tt.backend.BuildInvocation(&Config{Mode: "new", WorkDir: defaultWorkdir}, "task")
+		if invocation.Command != tt.command {
+			t.Fatalf("Command = %s, want %s", invocation.Command, tt.command)
 		}
 	}
 }
@@ -174,69 +175,6 @@ func TestBackendInvocationPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("legacy claude resume keeps explicit workdir", func(t *testing.T) {
-		cfg := &Config{Mode: "resume", SessionID: "sid", WorkDir: "/repo", Backend: "claude"}
-		invocation := legacyBackendInvocation(cfg, "claude", []string{"-p"})
-		if invocation.WorkDir != "/repo" {
-			t.Fatalf("legacy resume WorkDir = %q, want /repo", invocation.WorkDir)
-		}
-	})
-
-	t.Run("legacy path inherits registry backend policy", func(t *testing.T) {
-		cfg := &Config{Mode: "new", WorkDir: "/repo", Backend: "claude"}
-		invocation := legacyBackendInvocation(cfg, "fake-claude", []string{"-p", "injected"})
-		if invocation.Command != "fake-claude" {
-			t.Fatalf("Command = %q, want injected fake-claude", invocation.Command)
-		}
-		if !reflect.DeepEqual(invocation.Args, []string{"-p", "injected"}) {
-			t.Fatalf("Args = %v, want injected args", invocation.Args)
-		}
-		if !reflect.DeepEqual(invocation.UnsetEnvKeys, []string{"CLAUDECODE"}) {
-			t.Fatalf("UnsetEnvKeys = %v, want CLAUDECODE from backend policy", invocation.UnsetEnvKeys)
-		}
-		if invocation.WorkDir != "/repo" {
-			t.Fatalf("WorkDir = %q, want /repo from backend policy", invocation.WorkDir)
-		}
-		if invocation.ParseStream == nil {
-			t.Fatalf("legacy invocation missing stream parser")
-		}
-	})
-
-	t.Run("legacy nil config resolves default backend without panicking", func(t *testing.T) {
-		// Empty backend name falls back to the default backend in selectBackend,
-		// whose BuildInvocation must not receive a nil config (buildCodexArgs
-		// panics on nil).
-		invocation := legacyBackendInvocation(nil, "codex-cmd", []string{"-x"})
-		if invocation.BackendName != "codex" {
-			t.Fatalf("BackendName = %q, want codex (default backend)", invocation.BackendName)
-		}
-		if invocation.Command != "codex-cmd" {
-			t.Fatalf("Command = %q, want codex-cmd", invocation.Command)
-		}
-		if !reflect.DeepEqual(invocation.Args, []string{"-x"}) {
-			t.Fatalf("Args = %v, want injected args", invocation.Args)
-		}
-	})
-
-	t.Run("legacy unknown backend falls back to generic invocation", func(t *testing.T) {
-		cfg := &Config{Mode: "new", WorkDir: "/repo", Backend: "mystery"}
-		invocation := legacyBackendInvocation(cfg, "mystery-cmd", []string{"-x"})
-		if invocation.BackendName != "mystery" {
-			t.Fatalf("BackendName = %q, want mystery", invocation.BackendName)
-		}
-		if invocation.Command != "mystery-cmd" {
-			t.Fatalf("Command = %q, want mystery-cmd", invocation.Command)
-		}
-		if !reflect.DeepEqual(invocation.Args, []string{"-x"}) {
-			t.Fatalf("Args = %v, want [-x]", invocation.Args)
-		}
-		if len(invocation.UnsetEnvKeys) != 0 || invocation.WorkDir != "" {
-			t.Fatalf("generic invocation should carry no backend policy, got %+v", invocation)
-		}
-		if invocation.ParseStream == nil {
-			t.Fatalf("generic invocation missing stream parser")
-		}
-	})
 }
 
 func TestRuntimeInjectedEnvForInvocation(t *testing.T) {

--- a/code-dispatcher/config.go
+++ b/code-dispatcher/config.go
@@ -29,15 +29,16 @@ type ParallelConfig struct {
 
 // TaskSpec describes an individual task entry in the parallel config
 type TaskSpec struct {
-	ID           string          `json:"id"`
-	Task         string          `json:"task"`
-	WorkDir      string          `json:"workdir,omitempty"`
-	Dependencies []string        `json:"dependencies,omitempty"`
-	SessionID    string          `json:"session_id,omitempty"`
-	Backend      string          `json:"backend,omitempty"`
-	Mode         string          `json:"-"`
-	UseStdin     bool            `json:"-"`
-	Context      context.Context `json:"-"`
+	ID                string          `json:"id"`
+	Task              string          `json:"task"`
+	WorkDir           string          `json:"workdir,omitempty"`
+	Dependencies      []string        `json:"dependencies,omitempty"`
+	SessionID         string          `json:"session_id,omitempty"`
+	Backend           string          `json:"backend,omitempty"`
+	Mode              string          `json:"-"`
+	UseStdin          bool            `json:"-"`
+	Context           context.Context `json:"-"`
+	plannedInvocation *BackendInvocation
 }
 
 // TaskResult captures the execution outcome of a task

--- a/code-dispatcher/execution_lifecycle.go
+++ b/code-dispatcher/execution_lifecycle.go
@@ -385,10 +385,6 @@ func cancelReason(commandName string, ctx context.Context) string {
 		return "Context cancelled"
 	}
 
-	if commandName == "" {
-		commandName = defaultBackendName
-	}
-
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return fmt.Sprintf("%s execution timeout", commandName)
 	}

--- a/code-dispatcher/execution_lifecycle.go
+++ b/code-dispatcher/execution_lifecycle.go
@@ -386,7 +386,7 @@ func cancelReason(commandName string, ctx context.Context) string {
 	}
 
 	if commandName == "" {
-		commandName = backendCommand
+		commandName = defaultBackendName
 	}
 
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/code-dispatcher/executor.go
+++ b/code-dispatcher/executor.go
@@ -315,13 +315,17 @@ func defaultRunParallelTaskFn(task TaskSpec, timeout int) TaskResult {
 	}
 	task.Backend = backend.Name()
 	task.UseStdin = task.UseStdin || shouldUseStdin(task.Task, false)
+	task, invocation, err := planTaskInvocation(task, backend)
+	if err != nil {
+		return TaskResult{TaskID: task.ID, ExitCode: 1, Error: err.Error()}
+	}
 
 	parentCtx := context.Background()
 	if task.Context != nil {
 		parentCtx = task.Context
 		task.Context = nil
 	}
-	return runTaskWithContext(parentCtx, task, backend, true, timeout)
+	return executeTaskWithContext(parentCtx, task, invocation, true, timeout)
 }
 
 var runParallelTaskFn = defaultRunParallelTaskFn
@@ -593,63 +597,90 @@ func getStatusSymbols() (success, warning, failed string) {
 	return "✓", "⚠️", "✗"
 }
 
-func runTask(taskSpec TaskSpec, silent bool, timeoutSec int) TaskResult {
-	return runTaskWithContext(context.Background(), taskSpec, nil, silent, timeoutSec)
-}
+func planTaskInvocation(taskSpec TaskSpec, backend Backend) (TaskSpec, BackendInvocation, error) {
+	if backend == nil {
+		return taskSpec, BackendInvocation{}, fmt.Errorf("backend is required")
+	}
+	if taskSpec.Mode == "" {
+		taskSpec.Mode = "new"
+	}
+	if taskSpec.WorkDir == "" {
+		taskSpec.WorkDir = defaultWorkdir
+	}
+	if taskSpec.Mode == "resume" && strings.TrimSpace(taskSpec.SessionID) == "" {
+		return taskSpec, BackendInvocation{}, fmt.Errorf("resume mode requires non-empty session_id")
+	}
 
-func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Backend, silent bool, timeoutSec int) TaskResult {
-	parentCtx = effectiveTaskContext(parentCtx, taskSpec.Context)
-
-	result := TaskResult{TaskID: taskSpec.ID}
-	injectedLogger := taskLoggerFromContext(parentCtx)
-	logger := injectedLogger
-
+	taskSpec.Backend = backend.Name()
 	cfg := &Config{
 		Mode:      taskSpec.Mode,
 		Task:      taskSpec.Task,
 		SessionID: taskSpec.SessionID,
 		WorkDir:   taskSpec.WorkDir,
-		Backend:   defaultBackendName,
+		Backend:   taskSpec.Backend,
 	}
-
-	commandName := backendCommand
-	argsBuilder := buildArgsFn
-	if backend != nil {
-		cfg.Backend = backend.Name()
-	} else if taskSpec.Backend != "" {
-		cfg.Backend = taskSpec.Backend
-	} else if commandName != "" {
-		cfg.Backend = commandName
-	}
-
-	if cfg.Mode == "" {
-		cfg.Mode = "new"
-	}
-	if cfg.WorkDir == "" {
-		cfg.WorkDir = defaultWorkdir
-	}
-
-	if cfg.Mode == "resume" && strings.TrimSpace(cfg.SessionID) == "" {
-		result.ExitCode = 1
-		result.Error = "resume mode requires non-empty session_id"
-		return result
-	}
-
-	useStdin := taskSpec.UseStdin
 	targetArg := taskSpec.Task
-	if useStdin {
+	if taskSpec.UseStdin {
 		targetArg = "-"
 	}
 
-	invocation := BackendInvocation{}
-	if backend != nil {
-		invocation = backend.BuildInvocation(cfg, targetArg)
-	} else {
-		invocation = legacyBackendInvocation(cfg, commandName, argsBuilder(cfg, targetArg))
+	invocation := backend.BuildInvocation(cfg, targetArg)
+	if err := validateBackendInvocation(invocation); err != nil {
+		return taskSpec, BackendInvocation{}, err
 	}
-	if invocation.BackendName != "" {
-		cfg.Backend = invocation.BackendName
+	taskSpec.plannedInvocation = &invocation
+	return taskSpec, invocation, nil
+}
+
+func validateBackendInvocation(invocation BackendInvocation) error {
+	if normalizeBackendName(invocation.BackendName) == "" {
+		return fmt.Errorf("backend invocation missing backend name")
 	}
+	if strings.TrimSpace(invocation.Command) == "" {
+		return fmt.Errorf("backend invocation %q missing command", invocation.BackendName)
+	}
+	if invocation.ParseStream == nil {
+		return fmt.Errorf("backend invocation %q missing stream parser", invocation.BackendName)
+	}
+	return nil
+}
+
+func runTask(taskSpec TaskSpec, silent bool, timeoutSec int) TaskResult {
+	return runTaskWithContext(context.Background(), taskSpec, nil, silent, timeoutSec)
+}
+
+func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Backend, silent bool, timeoutSec int) TaskResult {
+	if taskSpec.plannedInvocation != nil {
+		return executeTaskWithContext(parentCtx, taskSpec, *taskSpec.plannedInvocation, silent, timeoutSec)
+	}
+
+	if backend == nil {
+		selected, err := selectBackendFn(taskSpec.Backend)
+		if err != nil {
+			return TaskResult{TaskID: taskSpec.ID, ExitCode: 1, Error: err.Error()}
+		}
+		backend = selected
+	}
+
+	plannedTask, invocation, err := planTaskInvocation(taskSpec, backend)
+	if err != nil {
+		return TaskResult{TaskID: taskSpec.ID, ExitCode: 1, Error: err.Error()}
+	}
+	return executeTaskWithContext(parentCtx, plannedTask, invocation, silent, timeoutSec)
+}
+
+func executeTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, invocation BackendInvocation, silent bool, timeoutSec int) TaskResult {
+	parentCtx = effectiveTaskContext(parentCtx, taskSpec.Context)
+
+	result := TaskResult{TaskID: taskSpec.ID}
+	if err := validateBackendInvocation(invocation); err != nil {
+		result.ExitCode = 1
+		result.Error = err.Error()
+		return result
+	}
+
+	injectedLogger := taskLoggerFromContext(parentCtx)
+	logger := injectedLogger
 
 	prefixMsg := func(msg string) string {
 		if taskSpec.ID == "" {
@@ -732,7 +763,7 @@ func runTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backend Ba
 		Context:      parentCtx,
 		Invocation:   invocation,
 		TaskText:     taskSpec.Task,
-		UseStdin:     useStdin,
+		UseStdin:     taskSpec.UseStdin,
 		TimeoutSec:   timeoutSec,
 		LogPath:      result.LogPath,
 		StdoutLogger: stdoutLogger,

--- a/code-dispatcher/executor.go
+++ b/code-dispatcher/executor.go
@@ -286,19 +286,12 @@ func newTaskLoggerHandle(taskID string) taskLoggerHandle {
 
 // defaultRunParallelTaskFn is the default implementation of runParallelTaskFn (exposed for test reset)
 func defaultRunParallelTaskFn(task TaskSpec, timeout int) TaskResult {
-	if task.WorkDir == "" {
-		task.WorkDir = defaultWorkdir
-	}
-	if task.Mode == "" {
-		task.Mode = "new"
+	backend, err := selectBackendFn(task.Backend)
+	if err != nil {
+		return TaskResult{TaskID: task.ID, ExitCode: 1, Error: err.Error()}
 	}
 
-	backendName := task.Backend
-	if backendName == "" {
-		backendName = defaultBackendName
-	}
-
-	promptFile := defaultPromptFileForBackend(backendName)
+	promptFile := defaultPromptFileForBackend(backend.Name())
 	if promptFile != "" {
 		prompt, err := readAgentPromptFile(promptFile)
 		if err != nil {
@@ -309,11 +302,6 @@ func defaultRunParallelTaskFn(task TaskSpec, timeout int) TaskResult {
 			task.Task = wrapTaskWithAgentPrompt(prompt, task.Task)
 		}
 	}
-	backend, err := selectBackendFn(backendName)
-	if err != nil {
-		return TaskResult{TaskID: task.ID, ExitCode: 1, Error: err.Error()}
-	}
-	task.Backend = backend.Name()
 	task.UseStdin = task.UseStdin || shouldUseStdin(task.Task, false)
 	task, invocation, err := planTaskInvocation(task, backend)
 	if err != nil {

--- a/code-dispatcher/executor_concurrent_test.go
+++ b/code-dispatcher/executor_concurrent_test.go
@@ -1415,9 +1415,6 @@ func TestExecutorCancelReasonAndCloseWithReason(t *testing.T) {
 	if !strings.Contains(cancelReason("cmd", cancelCtx), "Execution cancelled") {
 		t.Fatalf("expected cancellation reason")
 	}
-	if !strings.Contains(cancelReason("", cancelCtx), "codex") {
-		t.Fatalf("expected default command name in cancel reason")
-	}
 
 	rc := &reasonReadCloser{r: strings.NewReader("data"), closedC: make(chan struct{}, 1)}
 	closeWithReason(rc, "why")

--- a/code-dispatcher/executor_concurrent_test.go
+++ b/code-dispatcher/executor_concurrent_test.go
@@ -661,15 +661,7 @@ func TestExecutorRunTaskWithContext(t *testing.T) {
 		}
 	})
 
-	t.Run("legacyClaudeInvocationSetsDir", func(t *testing.T) {
-		origCommand := backendCommand
-		origBuildArgs := buildArgsFn
-		backendCommand = "claude"
-		buildArgsFn = buildClaudeArgs
-		t.Cleanup(func() {
-			backendCommand = origCommand
-			buildArgsFn = origBuildArgs
-		})
+	t.Run("selectedClaudeInvocationSetsDir", func(t *testing.T) {
 
 		var rc *execFakeRunner
 		newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
@@ -685,7 +677,7 @@ func TestExecutorRunTaskWithContext(t *testing.T) {
 			t.Fatalf("unexpected result: %+v", res)
 		}
 		if rc == nil || rc.dir != "/tmp" {
-			t.Fatalf("expected legacy claude invocation to set cmd.Dir, got runner=%v dir=%q", rc, rc.dir)
+			t.Fatalf("expected selected claude invocation to set cmd.Dir, got runner=%v dir=%q", rc, rc.dir)
 		}
 	})
 

--- a/code-dispatcher/invocation_plan_test.go
+++ b/code-dispatcher/invocation_plan_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type countingBackend struct {
+	builds int
+}
+
+func (b *countingBackend) Name() string { return "counting" }
+
+func (b *countingBackend) BuildInvocation(_ *Config, targetArg string) BackendInvocation {
+	b.builds++
+	return BackendInvocation{
+		BackendName: b.Name(),
+		Command:     "counting",
+		Args:        []string{targetArg},
+		ParseStream: parseJSONStreamInternal,
+	}
+}
+
+func TestRunTaskExecutesPreparedInvocationWithoutReplanning(t *testing.T) {
+	defer resetTestHooks()
+
+	backend := &countingBackend{}
+	task, invocation, err := planTaskInvocation(TaskSpec{
+		Task:    "task",
+		WorkDir: defaultWorkdir,
+		Mode:    "new",
+	}, backend)
+	if err != nil {
+		t.Fatalf("planTaskInvocation() error = %v", err)
+	}
+	if backend.builds != 1 {
+		t.Fatalf("BuildInvocation calls = %d, want 1", backend.builds)
+	}
+	if invocation.Command != "counting" {
+		t.Fatalf("Command = %q, want counting", invocation.Command)
+	}
+
+	fake := newFakeCmd(fakeCmdConfig{
+		StdoutPlan: []fakeStdoutEvent{{Data: `{"type":"item.completed","item":{"type":"agent_message","text":"done"}}` + "\n"}},
+	})
+	newCommandRunner = func(context.Context, string, ...string) commandRunner { return fake }
+
+	result := runTask(task, false, 5)
+	if result.ExitCode != 0 || result.Message != "done" {
+		t.Fatalf("runTask() result = %+v", result)
+	}
+	if backend.builds != 1 {
+		t.Fatalf("BuildInvocation calls after execution = %d, want 1", backend.builds)
+	}
+}
+
+func TestRunTaskRejectsUnknownBackendWithoutGenericFallback(t *testing.T) {
+	defer resetTestHooks()
+
+	started := false
+	newCommandRunner = func(context.Context, string, ...string) commandRunner {
+		started = true
+		return newFakeCmd(fakeCmdConfig{})
+	}
+
+	result := runTask(TaskSpec{Task: "task", Backend: "mystery"}, false, 5)
+	if result.ExitCode != 1 || !strings.Contains(result.Error, `unsupported backend "mystery"`) {
+		t.Fatalf("runTask() result = %+v", result)
+	}
+	if started {
+		t.Fatal("command runner started for an unsupported backend")
+	}
+}

--- a/code-dispatcher/logger_test.go
+++ b/code-dispatcher/logger_test.go
@@ -577,7 +577,7 @@ func TestLoggerCoverageSuite(t *testing.T) {
 
 		{"TestClaudeBuildArgs_ModesAndPermissions", TestClaudeBuildArgs_ModesAndPermissions},
 		{"TestVariousBackendsBuildArgs", TestVariousBackendsBuildArgs},
-		{"TestClaudeBuildArgs_BackendMetadata", TestClaudeBuildArgs_BackendMetadata},
+		{"TestBackendMetadata", TestBackendMetadata},
 	}
 
 	for _, tc := range suite {

--- a/code-dispatcher/main.go
+++ b/code-dispatcher/main.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -22,9 +21,8 @@ const (
 	// stderrCaptureLimit caps the rolling stderr tail attached to TaskResult.Error
 	// (and thus to execution reports). Full stderr still reaches the task log via
 	// stderrLogger; keep this small so failed tasks cannot flood report output.
-	stderrCaptureLimit    = 4 * 1024
-	defaultBackendName    = "codex"
-	defaultBackendCommand = "codex"
+	stderrCaptureLimit = 4 * 1024
+	defaultBackendName = "codex"
 
 	// stdout close reasons
 	stdoutCloseReasonWait  = "wait-done"
@@ -35,19 +33,16 @@ const (
 
 // Test hooks for dependency injection
 var (
-	stdinReader    io.Reader = os.Stdin
-	isTerminalFn             = defaultIsTerminal
-	backendCommand           = defaultBackendCommand
-	cleanupHook    func()
-	loggerPtr      atomic.Pointer[Logger]
+	stdinReader  io.Reader = os.Stdin
+	isTerminalFn           = defaultIsTerminal
+	cleanupHook  func()
+	loggerPtr    atomic.Pointer[Logger]
 
-	buildArgsFn        = buildCodexArgs
 	selectBackendFn    = selectBackend
 	commandContext     = exec.CommandContext
 	cleanupLogsFn      = cleanupOldLogs
 	signalNotifyCtxFn  = signal.NotifyContext
 	terminateCommandFn = terminateCommand
-	defaultBuildArgsFn = buildCodexArgs
 	runTaskFn          = runTask
 	exitFn             = os.Exit
 )
@@ -197,17 +192,6 @@ func run() (exitCode int) {
 	}
 	cfg.Backend = backend.Name()
 
-	cmdInjected := backendCommand != defaultBackendCommand
-	argsInjected := buildArgsFn != nil && reflect.ValueOf(buildArgsFn).Pointer() != reflect.ValueOf(defaultBuildArgsFn).Pointer()
-
-	// Wire selected backend into runtime hooks for the rest of the execution,
-	// but preserve any injected test hooks for the default backend.
-	if backend.Name() != defaultBackendName || !cmdInjected {
-		backendCommand = backend.Command()
-	}
-	if backend.Name() != defaultBackendName || !argsInjected {
-		buildArgsFn = backend.BuildArgs
-	}
 	logInfo(fmt.Sprintf("Selected backend: %s", backend.Name()))
 
 	timeoutSec := resolveTimeout()

--- a/code-dispatcher/main_integration_test.go
+++ b/code-dispatcher/main_integration_test.go
@@ -508,10 +508,9 @@ func TestRunNonParallelOutputsIncludeLogPathsIntegration(t *testing.T) {
 	os.Args = []string{"code-dispatcher", "--backend", "codex", "integration-log-check"}
 	stdinReader = strings.NewReader("")
 	isTerminalFn = func() bool { return true }
-	backendCommand = "echo"
-	buildArgsFn = func(cfg *Config, targetArg string) []string {
+	t.Cleanup(withBackend("echo", func(cfg *Config, targetArg string) []string {
 		return []string{`{"type":"thread.started","thread_id":"integration-session"}` + "\n" + `{"type":"item.completed","item":{"type":"agent_message","text":"done"}}`}
-	}
+	}))
 
 	var exitCode int
 	stderr := captureStderr(t, func() {
@@ -722,7 +721,7 @@ func TestRunStartupCleanupRemovesOrphansEndToEnd(t *testing.T) {
 		return time.Time{}
 	})
 
-	backendCommand = createFakeCodexScript(t, "tid-startup", "ok")
+	t.Cleanup(withBackend(createFakeCodexScript(t, "tid-startup", "ok"), nil))
 	stdinReader = strings.NewReader("")
 	isTerminalFn = func() bool { return true }
 	os.Args = []string{"code-dispatcher", "--backend", "codex", "task"}
@@ -889,7 +888,7 @@ func TestRunCleanupFlagEndToEnd_FailureDoesNotAffectStartup(t *testing.T) {
 	cleanupLogsFn = func() (CleanupStats, error) {
 		return CleanupStats{}, nil
 	}
-	backendCommand = createFakeCodexScript(t, "tid-cleanup-e2e", "ok")
+	t.Cleanup(withBackend(createFakeCodexScript(t, "tid-cleanup-e2e", "ok"), nil))
 	stdinReader = strings.NewReader("")
 	isTerminalFn = func() bool { return true }
 	os.Args = []string{"code-dispatcher", "--backend", "codex", "post-cleanup task"}

--- a/code-dispatcher/main_test.go
+++ b/code-dispatcher/main_test.go
@@ -25,11 +25,9 @@ func resetTestHooks() {
 	resetRuntimeSettingsForTest()
 	stdinReader = os.Stdin
 	isTerminalFn = defaultIsTerminal
-	backendCommand = "codex"
 	cleanupHook = nil
 	cleanupLogsFn = cleanupOldLogs
 	signalNotifyCtxFn = signal.NotifyContext
-	buildArgsFn = buildCodexArgs
 	selectBackendFn = selectBackend
 	removeLogFileFn = os.Remove
 	commandContext = exec.CommandContext
@@ -782,10 +780,9 @@ func TestFakeCmdInfra(t *testing.T) {
 		newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
 			return fake
 		}
-		buildArgsFn = func(cfg *Config, targetArg string) []string {
+		t.Cleanup(withBackend("fake-cmd", func(cfg *Config, targetArg string) []string {
 			return []string{targetArg}
-		}
-		backendCommand = "fake-cmd"
+		}))
 
 		res := runTask(TaskSpec{Task: "ignored"}, false, 2)
 		if res.ExitCode != 0 {
@@ -828,10 +825,9 @@ func TestRunTask_WaitBeforeParse(t *testing.T) {
 	newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
 		return fake
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string {
+	t.Cleanup(withBackend("fake-cmd", func(cfg *Config, targetArg string) []string {
 		return []string{targetArg}
-	}
-	backendCommand = "fake-cmd"
+	}))
 
 	start := time.Now()
 	result := runTask(TaskSpec{Task: "ignored"}, false, 5)
@@ -875,10 +871,9 @@ func TestRunTask_ParseStall(t *testing.T) {
 	newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
 		return blockingCmd
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string {
+	t.Cleanup(withBackend("fake-cmd", func(cfg *Config, targetArg string) []string {
 		return []string{targetArg}
-	}
-	backendCommand = "fake-cmd"
+	}))
 
 	start := time.Now()
 	result := runTask(TaskSpec{Task: "stall"}, false, 60)
@@ -941,10 +936,9 @@ func TestRunTask_ContextTimeout(t *testing.T) {
 	newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
 		return fake
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string {
+	t.Cleanup(withBackend("fake-cmd", func(cfg *Config, targetArg string) []string {
 		return []string{targetArg}
-	}
-	backendCommand = "fake-cmd"
+	}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -1015,8 +1009,7 @@ func TestRunTask_ForcesStopAfterCompletion(t *testing.T) {
 	newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
 		return fake
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
-	backendCommand = "fake-cmd"
+	t.Cleanup(withBackend("fake-cmd", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 
 	start := time.Now()
 	result := runTaskWithContext(context.Background(), TaskSpec{Task: "done", WorkDir: defaultWorkdir}, nil, false, 60)
@@ -1055,8 +1048,7 @@ func TestRunTask_ForcesStopAfterTurnCompleted(t *testing.T) {
 	newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
 		return fake
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
-	backendCommand = "fake-cmd"
+	t.Cleanup(withBackend("fake-cmd", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 
 	start := time.Now()
 	result := runTaskWithContext(context.Background(), TaskSpec{Task: "done", WorkDir: defaultWorkdir}, nil, false, 60)
@@ -1096,8 +1088,7 @@ func TestRunTask_DoesNotTerminateBeforeThreadCompleted(t *testing.T) {
 	newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
 		return fake
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
-	backendCommand = "fake-cmd"
+	t.Cleanup(withBackend("fake-cmd", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 
 	start := time.Now()
 	result := runTaskWithContext(context.Background(), TaskSpec{Task: "done", WorkDir: defaultWorkdir}, nil, false, 60)
@@ -1881,8 +1872,9 @@ func TestBackendNamesAndCommands(t *testing.T) {
 		if backend.Name() != expected[i].name {
 			t.Fatalf("backend %d name = %s, want %s", i, backend.Name(), expected[i].name)
 		}
-		if backend.Command() != expected[i].command {
-			t.Fatalf("backend %d command = %s, want %s", i, backend.Command(), expected[i].command)
+		invocation := backend.BuildInvocation(&Config{Mode: "new", WorkDir: defaultWorkdir}, "task")
+		if invocation.Command != expected[i].command {
+			t.Fatalf("backend %d command = %s, want %s", i, invocation.Command, expected[i].command)
 		}
 	}
 }
@@ -2317,7 +2309,7 @@ func TestRunWarnsWhenLogRemovalFails(t *testing.T) {
 		}
 		return os.Remove(path)
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
+	t.Cleanup(withBackend("codex", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 	selectBackendFn = func(name string) (Backend, error) {
 		return testBackend{name: name, command: "unused"}, nil
 	}
@@ -2465,8 +2457,7 @@ func TestRunReadPipedTask(t *testing.T) {
 
 func TestRunTask_CommandNotFound(t *testing.T) {
 	defer resetTestHooks()
-	backendCommand = "nonexistent-command-xyz"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
+	t.Cleanup(withBackend("nonexistent-command-xyz", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 	res := runTask(TaskSpec{Task: "task"}, false, 10)
 	if res.ExitCode != 127 {
 		t.Errorf("exitCode = %d, want 127", res.ExitCode)
@@ -2484,8 +2475,7 @@ func TestRunTask_StartError(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	backendCommand = tmpFile.Name()
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{} }
+	t.Cleanup(withBackend(tmpFile.Name(), func(cfg *Config, targetArg string) []string { return []string{} }))
 
 	res := runTask(TaskSpec{Task: "task"}, false, 1)
 	if res.ExitCode != 1 || !strings.Contains(res.Error, "failed to start") {
@@ -2495,8 +2485,7 @@ func TestRunTask_StartError(t *testing.T) {
 
 func TestRunTask_WithEcho(t *testing.T) {
 	defer resetTestHooks()
-	backendCommand = "echo"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
+	t.Cleanup(withBackend("echo", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 
 	jsonOutput := `{"type":"thread.started","thread_id":"test-session"}
 {"type":"item.completed","item":{"type":"agent_message","text":"Test output"}}`
@@ -2581,8 +2570,7 @@ func TestRunTask_LogPathWithActiveLogger(t *testing.T) {
 	}
 	setLogger(logger)
 
-	backendCommand = "echo"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
+	t.Cleanup(withBackend("echo", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 
 	jsonOutput := `{"type":"thread.started","thread_id":"fake-thread"}
 {"type":"item.completed","item":{"type":"agent_message","text":"ok"}}`
@@ -2599,8 +2587,7 @@ func TestRunTask_LogPathWithActiveLogger(t *testing.T) {
 func TestRunTask_LogPathWithTempLogger(t *testing.T) {
 	defer resetTestHooks()
 
-	backendCommand = "echo"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
+	t.Cleanup(withBackend("echo", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 
 	jsonOutput := `{"type":"thread.started","thread_id":"temp-thread"}
 {"type":"item.completed","item":{"type":"agent_message","text":"temp"}}`
@@ -2637,8 +2624,7 @@ func TestRunTask_LogPathOnStartError(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	backendCommand = tmpFile.Name()
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{} }
+	t.Cleanup(withBackend(tmpFile.Name(), func(cfg *Config, targetArg string) []string { return []string{} }))
 
 	result := runTask(TaskSpec{Task: "ignored"}, false, 5)
 	if result.ExitCode == 0 {
@@ -2651,8 +2637,7 @@ func TestRunTask_LogPathOnStartError(t *testing.T) {
 
 func TestRunTask_NoMessage(t *testing.T) {
 	defer resetTestHooks()
-	backendCommand = "echo"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
+	t.Cleanup(withBackend("echo", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 	jsonOutput := `{"type":"thread.started","thread_id":"test-session"}`
 	res := runTask(TaskSpec{Task: jsonOutput}, false, 10)
 	if res.ExitCode != 1 || res.Error == "" {
@@ -2662,8 +2647,7 @@ func TestRunTask_NoMessage(t *testing.T) {
 
 func TestRunTask_WithStdin(t *testing.T) {
 	defer resetTestHooks()
-	backendCommand = "cat"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{} }
+	t.Cleanup(withBackend("cat", func(cfg *Config, targetArg string) []string { return []string{} }))
 	jsonInput := `{"type":"item.completed","item":{"type":"agent_message","text":"from stdin"}}`
 	res := runTask(TaskSpec{Task: jsonInput, UseStdin: true}, false, 10)
 	if res.ExitCode != 0 || res.Message != "from stdin" {
@@ -2673,8 +2657,7 @@ func TestRunTask_WithStdin(t *testing.T) {
 
 func TestRunTask_ExitError(t *testing.T) {
 	defer resetTestHooks()
-	backendCommand = "false"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{} }
+	t.Cleanup(withBackend("false", func(cfg *Config, targetArg string) []string { return []string{} }))
 	res := runTask(TaskSpec{Task: "noop"}, false, 10)
 	if res.ExitCode == 0 || res.Error == "" {
 		t.Fatalf("expected failure, got %+v", res)
@@ -2688,7 +2671,7 @@ func TestRunTask_StdinPipeError(t *testing.T) {
 		cmd.Stdin = os.Stdin
 		return cmd
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{} }
+	t.Cleanup(withBackend("codex", func(cfg *Config, targetArg string) []string { return []string{} }))
 	res := runTask(TaskSpec{Task: "data", UseStdin: true}, false, 1)
 	if res.ExitCode != 1 || !strings.Contains(res.Error, "stdin pipe") {
 		t.Fatalf("expected stdin pipe error, got %+v", res)
@@ -2702,7 +2685,7 @@ func TestRunTask_StdoutPipeError(t *testing.T) {
 		cmd.Stdout = os.Stdout
 		return cmd
 	}
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{} }
+	t.Cleanup(withBackend("codex", func(cfg *Config, targetArg string) []string { return []string{} }))
 	res := runTask(TaskSpec{Task: "noop"}, false, 1)
 	if res.ExitCode != 1 || !strings.Contains(res.Error, "stdout pipe") {
 		t.Fatalf("expected stdout pipe error, got %+v", res)
@@ -2711,8 +2694,7 @@ func TestRunTask_StdoutPipeError(t *testing.T) {
 
 func TestRunTask_Timeout(t *testing.T) {
 	defer resetTestHooks()
-	backendCommand = "sleep"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{"2"} }
+	t.Cleanup(withBackend("sleep", func(cfg *Config, targetArg string) []string { return []string{"2"} }))
 	res := runTask(TaskSpec{Task: "ignored"}, false, 1)
 	if res.ExitCode != 124 || !strings.Contains(res.Error, "timeout") {
 		t.Fatalf("expected timeout, got %+v", res)
@@ -2725,8 +2707,7 @@ func TestRunTask_SignalHandling(t *testing.T) {
 	}
 
 	defer resetTestHooks()
-	backendCommand = "sleep"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{"5"} }
+	t.Cleanup(withBackend("sleep", func(cfg *Config, targetArg string) []string { return []string{"5"} }))
 
 	resultCh := make(chan TaskResult, 1)
 	go func() { resultCh <- runTask(TaskSpec{Task: "ignored"}, false, 5) }()
@@ -2770,8 +2751,7 @@ func TestRunSilentMode(t *testing.T) {
 	defer resetTestHooks()
 	jsonOutput := `{"type":"thread.started","thread_id":"silent-session"}
 {"type":"item.completed","item":{"type":"agent_message","text":"quiet"}}`
-	backendCommand = "echo"
-	buildArgsFn = func(cfg *Config, targetArg string) []string { return []string{targetArg} }
+	t.Cleanup(withBackend("echo", func(cfg *Config, targetArg string) []string { return []string{targetArg} }))
 
 	capture := func(silent bool) string {
 		oldStderr := os.Stderr
@@ -4110,7 +4090,7 @@ func TestRun_CleanupFailureDoesNotBlock(t *testing.T) {
 		panic("boom")
 	}
 
-	backendCommand = createFakeCodexScript(t, "tid-cleanup", "ok")
+	t.Cleanup(withBackend(createFakeCodexScript(t, "tid-cleanup", "ok"), nil))
 	stdinReader = strings.NewReader("")
 	isTerminalFn = func() bool { return true }
 	os.Args = []string{"code-dispatcher", "--backend", "codex", "task"}
@@ -4243,10 +4223,9 @@ func TestParallelLogPathInSerialMode(t *testing.T) {
 	os.Args = []string{"code-dispatcher", "--backend", "codex", "do-stuff"}
 	stdinReader = strings.NewReader("")
 	isTerminalFn = func() bool { return true }
-	backendCommand = "echo"
-	buildArgsFn = func(cfg *Config, targetArg string) []string {
+	t.Cleanup(withBackend("echo", func(cfg *Config, targetArg string) []string {
 		return []string{`{"type":"thread.started","thread_id":"cli-session"}` + "\n" + `{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}`}
-	}
+	}))
 
 	var exitCode int
 	stderr := captureStderr(t, func() {

--- a/code-dispatcher/resume_matrix_test.go
+++ b/code-dispatcher/resume_matrix_test.go
@@ -71,10 +71,11 @@ func TestResumeConversation_SupportedBackends(t *testing.T) {
 			t.Setenv("USERPROFILE", home)
 
 			var calls int
+			expectedCommand := tt.backend.BuildInvocation(&Config{Mode: "new", WorkDir: defaultWorkdir}, "task").Command
 			newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
 				calls++
-				if name != tt.backend.Command() {
-					t.Fatalf("command name=%q, want %q", name, tt.backend.Command())
+				if name != expectedCommand {
+					t.Fatalf("command name=%q, want %q", name, expectedCommand)
 				}
 				if calls == 1 {
 					if err := tt.checkNewArgs(args); err != nil {

--- a/code-dispatcher/serial_invocation_planner.go
+++ b/code-dispatcher/serial_invocation_planner.go
@@ -32,12 +32,6 @@ func planSerialInvocation(cfg *Config, backend Backend) (*serialInvocationPlan, 
 	}
 
 	useStdin := cfg.ExplicitStdin || shouldUseStdin(taskText, piped)
-	targetArg := taskText
-	if useStdin {
-		targetArg = "-"
-	}
-
-	invocation := backend.BuildInvocation(cfg, targetArg)
 	taskSpec := TaskSpec{
 		Task:      taskText,
 		WorkDir:   cfg.WorkDir,
@@ -45,6 +39,10 @@ func planSerialInvocation(cfg *Config, backend Backend) (*serialInvocationPlan, 
 		SessionID: cfg.SessionID,
 		Backend:   cfg.Backend,
 		UseStdin:  useStdin,
+	}
+	taskSpec, invocation, err := planTaskInvocation(taskSpec, backend)
+	if err != nil {
+		return nil, err
 	}
 
 	return &serialInvocationPlan{

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+bash scripts/quality-check.sh
+bash scripts/test-coverage.sh
+python3 test_runtime_assets.py


### PR DESCRIPTION
Closes #56

## What changed

- execute the exact prepared `BackendInvocation` in serial and parallel paths; remove the legacy invocation rebuild path and the generic unknown-backend fallback
- make the Chinese and English READMEs defer binary/PATH layout to the manifest-driven installer output instead of duplicating a fixed `bin` path
- add one `scripts/verify.sh` entry point and use it for both pull-request CI and release publishing
- add regression coverage for one-time invocation planning and unsupported-backend rejection

## Why

PRs #57 and #58 fixed the confirmed bugs and most follow-up cleanup, but three closeout gaps remained: startup output and execution could consume separately built invocations, documentation still duplicated the binary install directory, and release publishing did not run the installer/runtime-asset contract tests.

This PR removes those remaining parallel truths rather than adding another compatibility layer.

## Validation

The branch is generated and committed only after the exact final tree passes:

- `scripts/quality-check.sh` (`gofmt`, `go mod tidy`, `go vet`, `staticcheck`, complexity gate)
- `scripts/test-coverage.sh` (`go test -race` plus coverage gate)
- `python3 test_runtime_assets.py`

Commit author and committer are configured as `makoMakoGo <48956204+makoMakoGo@users.noreply.github.com>`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes issue #56 by planning a single backend invocation per task and executing it consistently in serial and parallel. Removes legacy rebuild hooks, backend command/args wiring, and the unknown-backend fallback; CI and docs now use a single `scripts/verify.sh`.

- **Refactors**
  - Plan once via `planTaskInvocation`, execute with `executeTaskWithContext`, validate with `validateBackendInvocation`.
  - `TaskSpec` stores `plannedInvocation`; parallel flow selects backends via `selectBackendFn` and errors on unknown backends (no generic fallback).
  - Backend API is `Name` + `BuildInvocation`; removed `Command()`/`BuildArgs()` and the legacy rebuild path.
  - `cancelReason` no longer inserts a default command name.
  - CI/release workflows call `scripts/verify.sh`; READMEs defer PATH to `install.py` and `runtime_assets.json`.

- **Migration**
  - Tests should use `withBackend` and assert via `BuildInvocation` (or `planTaskInvocation` + `runTask`). No user changes.

<sup>Written for commit 0c1b259d55515f1b57b1f70b01f385cd8c9f30bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/makoMakoGo/code-dispatcher-toolkit/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 安装程序会根据运行时清单显示实际安装路径，并生成适合当前环境的 PATH 持久化提示。
  - 任务执行在未知后端场景会更早失败并明确报错，提升可预期性。
- **文档**
  - 简化本地验证流程：统一使用 `bash scripts/verify.sh`。
  - 安装与验证说明已更新（移除固定路径示例，英文/中文同步）。
- **测试与质量**
  - CI 与发布校验流程统一为“Run verification gate”，复用同一验证入口，包含格式/静态检查、覆盖率门禁与运行时资源校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->